### PR TITLE
update reflections to 0.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 ./build/
+telegram-bot/build/*
 ./out/
 ./lib/build/*
 *.class

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ ktor = "2.3.6"
 mu-logging = "3.0.5"
 logback = "1.4.12"
 jackson = "2.16.0"
-reflections = "0.10"
+reflections = "0.10.2"
 
 kotlin = "1.9.21"
 coroutines = "1.7.3"

--- a/telegram-bot/src/test/kotlin/eu/vendeli/AnnotationsTest.kt
+++ b/telegram-bot/src/test/kotlin/eu/vendeli/AnnotationsTest.kt
@@ -11,6 +11,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.maps.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import java.lang.reflect.InvocationTargetException
 
@@ -42,6 +43,17 @@ class AnnotationsTest : BotTestContext() {
             actionsFromAnnotations.updateHandlers.size shouldBe 2
             actionsFromAnnotations.updateHandlers[UpdateType.MESSAGE].shouldNotBeNull()
         }
+    }
+
+    /**
+     * Actions were lost if a controller has unannotated method, that has a return value specified
+     */
+    @Test
+    fun `annotated methods scanning in a class with unannotated methods test`() {
+        val actionsFromAnnotations = TelegramActionsCollector.collect("other.pckg2")
+
+        actionsFromAnnotations.commands.keys shouldContain "testCommandActionThatShouldBeFound"
+        actionsFromAnnotations.inputs.keys shouldContain "testInputActionThatShouldBeFound"
     }
 
     @Test

--- a/telegram-bot/src/test/kotlin/other/pckg2/AnnotatedController.kt
+++ b/telegram-bot/src/test/kotlin/other/pckg2/AnnotatedController.kt
@@ -1,0 +1,24 @@
+package other.pckg2
+
+import eu.vendeli.tgbot.TelegramBot
+import eu.vendeli.tgbot.annotations.CommandHandler
+import eu.vendeli.tgbot.annotations.InputHandler
+import eu.vendeli.tgbot.types.User
+
+@FunctionalInterface
+class AnnotatedController(
+    private val test: List<String>
+) {
+
+    fun testString(): String {
+        return "someString"
+    }
+
+    @CommandHandler(["testCommandActionThatShouldBeFound"])
+    suspend fun testCommandActionThatShouldBeFound(user: User, bot: TelegramBot) {
+    }
+
+    @InputHandler(["testInputActionThatShouldBeFound"])
+    suspend fun testInputActionThatShouldBeFound(user: User, bot: TelegramBot) {
+    }
+}


### PR DESCRIPTION
## Fix lost actions on reflections scan

In current version, class that has public unannotated methods is skipped during actions scan.

### This action will be found

```kotlin
class Actions {

  @CommandHandler(["/start"])
  suspend fun start(user: User, bot: TelegramBot) {
      message { "Hello, what's your name?" }.send(user, bot)
      bot.inputListener.set(user) { "conversation" }
  }

}
```

### This action will be lost because of a separate public method

```kotlin
class Actions {

  fun doABarrelRoll() {
    println("smth")
  }

  @CommandHandler(["/start"])
  suspend fun start(user: User, bot: TelegramBot) {
      message { "Hello, what's your name?" }.send(user, bot)
      bot.inputListener.set(user) { "conversation" }
  }

}
```

### Update reflections

Eventually, I found out, that updating to a slightly newer version of reflections (`0.10` -> `0.10.2`) resolves this issue

### P.S.

It is really not obvious, that running tests locally requires several ENV variables. It would be neat to have their description somewhere in CONTRIBUTING.md. Maybe I just missed their description, but I struggled to find it.

---

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other
  open [Pull Requests](https://github.com/vendelieu/telegram-bot/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
