### PR TITLE
5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Telegram-bot changelog
 
+## 5.1.0
+
+* Fixed multipart requests data redundant quotation.
+* Returned `logback` as logger for `jvm` target.
+* Moved inline mode methods to extension interface from separate `InlinableAction`.
+* Added `Any` upperbounds for `Autowiring` interface to avoid wrong behaviour.
+* Covered 7.2 TelegramApi changes.
+
 ### 5.0.5
 
 * Fix nullable type resolving issue for `Autowiring` mechanics.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,3 +23,8 @@ tasks.create("prepareRelease") {
 
     dependsOn("telegram-bot:apiCheck")
 }
+
+tasks.create("polishingRelease") {
+    dependsOn("telegram-bot:kdocUpdate")
+    dependsOn("generateBotSc")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,4 +12,14 @@ plugins {
     alias(libs.plugins.deteKT) apply false
 }
 
-tasks.register<ScGenerator>("generateBotExt")
+tasks.register<ScGenerator>("generateBotSc")
+
+tasks.create("prepareRelease") {
+    dependsOn("ksp:formatKotlin")
+    dependsOn("telegram-bot:formatKotlin")
+
+    dependsOn("ksp:detekt")
+    dependsOn("telegram-bot:detekt")
+
+    dependsOn("telegram-bot:apiCheck")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,3 @@ tasks.create("prepareRelease") {
 
     dependsOn("telegram-bot:apiCheck")
 }
-
-tasks.create("polishingRelease") {
-    dependsOn("telegram-bot:kdocUpdate")
-    dependsOn("generateBotSc")
-}

--- a/buildSrc/src/main/kotlin/Kdokker.kt
+++ b/buildSrc/src/main/kotlin/Kdokker.kt
@@ -14,7 +14,7 @@ data class Api(
 data class ApiEntity(
     var name: String,
     var href: String,
-    var description: List<String>,
+    var description: List<String>? = null,
     var returns: List<String> = emptyList(),
     var fields: List<Field> = emptyList(),
 )
@@ -69,7 +69,7 @@ abstract class Kdokker : DefaultTask() {
                 ?: jsonRes.methods["send" + methodName.beginWithUpperCase()]
                 ?: return@forEach
             var kdoc = "/**$NEWLINE"
-            kdoc += methodMeta.description.joinToString("$NEWLINE * ", " * ")
+            kdoc += methodMeta.description?.joinToString("$NEWLINE * ", " * ") ?: ""
             kdoc += "$NEWLINE * Api reference: ${methodMeta.href}"
             kdoc += "$NEWLINE * "
 
@@ -98,7 +98,7 @@ abstract class Kdokker : DefaultTask() {
             }
 
             var kdoc = "/**$NEWLINE"
-            kdoc += classMeta.description.joinToString("$NEWLINE * ", " * ")
+            kdoc += classMeta.description?.joinToString("$NEWLINE * ", " * ") ?: ""
             kdoc += NEWLINE + " * Api reference: ${classMeta.href}"
             kdoc += "$NEWLINE * "
             kdoc += classMeta.fields.joinToString("$NEWLINE * ") {

--- a/buildSrc/src/main/kotlin/Kdokker.kt
+++ b/buildSrc/src/main/kotlin/Kdokker.kt
@@ -78,7 +78,7 @@ abstract class Kdokker : DefaultTask() {
             }
 
             kdoc += NEWLINE + methodMeta.returns.joinToString("|", " * @returns ") { "[$it]" }
-            kdoc += "$NEWLINE*/$NEWLINE"
+            kdoc += "$NEWLINE */$NEWLINE"
 
             modifiedContent = modifiedContent.replace(method.value, kdoc + method.value)
 
@@ -104,7 +104,7 @@ abstract class Kdokker : DefaultTask() {
             kdoc += classMeta.fields.joinToString("$NEWLINE * ") {
                 "@property " + it.name.snakeToCamelCase() + " " + it.description
             }
-            kdoc += "$NEWLINE*/$NEWLINE"
+            kdoc += "$NEWLINE */$NEWLINE"
             modifiedContent = modifiedContent.replace(clazz.value, kdoc + clazz.value)
 
             file.writeText(modifiedContent)

--- a/buildSrc/src/main/kotlin/Kdokker.kt
+++ b/buildSrc/src/main/kotlin/Kdokker.kt
@@ -70,7 +70,7 @@ abstract class Kdokker : DefaultTask() {
                 ?: return@forEach
             var kdoc = "/**$NEWLINE"
             kdoc += methodMeta.description?.joinToString("$NEWLINE * ", " * ") ?: ""
-            kdoc += "$NEWLINE * Api reference: ${methodMeta.href}"
+            kdoc += "$NEWLINE * $NEWLINE * Api reference: ${methodMeta.href}"
             kdoc += "$NEWLINE * "
 
             kdoc += methodMeta.fields.joinToString("$NEWLINE * ") {
@@ -99,7 +99,7 @@ abstract class Kdokker : DefaultTask() {
 
             var kdoc = "/**$NEWLINE"
             kdoc += classMeta.description?.joinToString("$NEWLINE * ", " * ") ?: ""
-            kdoc += NEWLINE + " * Api reference: ${classMeta.href}"
+            kdoc += "$NEWLINE * $NEWLINE * Api reference: ${classMeta.href}"
             kdoc += "$NEWLINE * "
             kdoc += classMeta.fields.joinToString("$NEWLINE * ") {
                 "@property " + it.name.snakeToCamelCase() + " " + it.description

--- a/buildSrc/src/main/resources/api.json
+++ b/buildSrc/src/main/resources/api.json
@@ -1,7 +1,7 @@
 {
-  "version": "Bot API 7.1",
-  "release_date": "February 16, 2024",
-  "changelog": "https://core.telegram.org/bots/api#february-16-2024",
+  "version": "Bot API 7.2",
+  "release_date": "March 31, 2024",
+  "changelog": "https://core.telegram.org/bots/api#march-31-2024",
   "methods": {
     "getUpdates": {
       "name": "getUpdates",
@@ -187,6 +187,14 @@
       ],
       "fields": [
         {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
+        {
           "name": "chat_id",
           "types": [
             "Integer",
@@ -268,7 +276,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -376,7 +384,7 @@
             "Array of Integer"
           ],
           "required": true,
-          "description": "Identifiers of 1-100 messages in the chat from_chat_id to forward. The identifiers must be specified in a strictly increasing order."
+          "description": "A JSON-serialized list of 1-100 identifiers of messages in the chat from_chat_id to forward. The identifiers must be specified in a strictly increasing order."
         },
         {
           "name": "disable_notification",
@@ -543,7 +551,7 @@
             "Array of Integer"
           ],
           "required": true,
-          "description": "Identifiers of 1-100 messages in the chat from_chat_id to copy. The identifiers must be specified in a strictly increasing order."
+          "description": "A JSON-serialized list of 1-100 identifiers of messages in the chat from_chat_id to copy. The identifiers must be specified in a strictly increasing order."
         },
         {
           "name": "disable_notification",
@@ -581,6 +589,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -672,7 +688,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -687,6 +703,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -803,7 +827,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -817,6 +841,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -917,7 +949,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -931,6 +963,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1063,7 +1103,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -1077,6 +1117,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1201,7 +1249,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -1215,6 +1263,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1306,7 +1362,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -1320,6 +1376,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1404,7 +1468,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -1418,6 +1482,14 @@
         "Array of Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1482,6 +1554,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1580,7 +1660,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -1594,6 +1674,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1708,7 +1796,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -1722,6 +1810,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1804,7 +1900,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -1818,6 +1914,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -1964,7 +2068,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -1978,6 +2082,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -2036,7 +2148,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account"
         }
       ]
     },
@@ -2052,6 +2164,14 @@
       ],
       "fields": [
         {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the action will be sent"
+        },
+        {
           "name": "chat_id",
           "types": [
             "Integer",
@@ -2066,7 +2186,7 @@
             "Integer"
           ],
           "required": false,
-          "description": "Unique identifier for the target message thread; supergroups only"
+          "description": "Unique identifier for the target message thread; for supergroups only"
         },
         {
           "name": "action",
@@ -2111,7 +2231,7 @@
             "Array of ReactionType"
           ],
           "required": false,
-          "description": "New list of reaction types to set on the message. Currently, as non-premium users, bots can set up to one reaction per message. A custom emoji reaction can be used if it is either already present on the message or explicitly allowed by chat administrators."
+          "description": "A JSON-serialized list of reaction types to set on the message. Currently, as non-premium users, bots can set up to one reaction per message. A custom emoji reaction can be used if it is either already present on the message or explicitly allowed by chat administrators."
         },
         {
           "name": "is_big",
@@ -2436,7 +2556,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Pass True if the administrator can post messages in the channel, or access channel statistics; channels only"
+          "description": "Pass True if the administrator can post messages in the channel, or access channel statistics; for channels only"
         },
         {
           "name": "can_edit_messages",
@@ -2444,7 +2564,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Pass True if the administrator can edit messages of other users and can pin messages; channels only"
+          "description": "Pass True if the administrator can edit messages of other users and can pin messages; for channels only"
         },
         {
           "name": "can_pin_messages",
@@ -2452,7 +2572,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Pass True if the administrator can pin messages, supergroups only"
+          "description": "Pass True if the administrator can pin messages; for supergroups only"
         },
         {
           "name": "can_manage_topics",
@@ -2460,7 +2580,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Pass True if the user is allowed to create, rename, close, and reopen forum topics, supergroups only"
+          "description": "Pass True if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only"
         }
       ]
     },
@@ -3607,6 +3727,26 @@
         }
       ]
     },
+    "getBusinessConnection": {
+      "name": "getBusinessConnection",
+      "href": "https://core.telegram.org/bots/api#getbusinessconnection",
+      "description": [
+        "Use this method to get information about the connection of the bot with a business account. Returns a BusinessConnection object on success."
+      ],
+      "returns": [
+        "BusinessConnection"
+      ],
+      "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "Unique identifier of the business connection"
+        }
+      ]
+    },
     "setMyCommands": {
       "name": "setMyCommands",
       "href": "https://core.telegram.org/bots/api#setmycommands",
@@ -4419,7 +4559,7 @@
             "Array of Integer"
           ],
           "required": true,
-          "description": "Identifiers of 1-100 messages to delete. See deleteMessage for limitations on which messages can be deleted"
+          "description": "A JSON-serialized list of 1-100 identifiers of messages to delete. See deleteMessage for limitations on which messages can be deleted"
         }
       ]
     },
@@ -4433,6 +4573,14 @@
         "Message"
       ],
       "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
         {
           "name": "chat_id",
           "types": [
@@ -4457,7 +4605,7 @@
             "String"
           ],
           "required": true,
-          "description": "Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP sticker from the Internet, or upload a new .WEBP or .TGS sticker using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files. Video stickers can only be sent by a file_id. Animated stickers can't be sent via an HTTP URL."
+          "description": "Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP sticker from the Internet, or upload a new .WEBP, .TGS, or .WEBM sticker using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files. Video and animated stickers can't be sent via an HTTP URL."
         },
         {
           "name": "emoji",
@@ -4500,7 +4648,7 @@
             "ForceReply"
           ],
           "required": false,
-          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user."
+          "description": "Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account."
         }
       ]
     },
@@ -4540,7 +4688,7 @@
             "Array of String"
           ],
           "required": true,
-          "description": "List of custom emoji identifiers. At most 200 custom emoji identifiers can be specified."
+          "description": "A JSON-serialized list of custom emoji identifiers. At most 200 custom emoji identifiers can be specified."
         }
       ]
     },
@@ -4548,7 +4696,7 @@
       "name": "uploadStickerFile",
       "href": "https://core.telegram.org/bots/api#uploadstickerfile",
       "description": [
-        "Use this method to upload a file with a sticker for later use in the createNewStickerSet and addStickerToSet methods (the file can be used multiple times). Returns the uploaded File on success."
+        "Use this method to upload a file with a sticker for later use in the createNewStickerSet, addStickerToSet, or replaceStickerInSet methods (the file can be used multiple times). Returns the uploaded File on success."
       ],
       "returns": [
         "File"
@@ -4623,14 +4771,6 @@
           "description": "A JSON-serialized list of 1-50 initial stickers to be added to the sticker set"
         },
         {
-          "name": "sticker_format",
-          "types": [
-            "String"
-          ],
-          "required": true,
-          "description": "Format of stickers in the set, must be one of \"static\", \"animated\", \"video\""
-        },
-        {
           "name": "sticker_type",
           "types": [
             "String"
@@ -4652,7 +4792,7 @@
       "name": "addStickerToSet",
       "href": "https://core.telegram.org/bots/api#addstickertoset",
       "description": [
-        "Use this method to add a new sticker to a set created by the bot. The format of the added sticker must match the format of the other stickers in the set. Emoji sticker sets can have up to 200 stickers. Animated and video sticker sets can have up to 50 stickers. Static sticker sets can have up to 120 stickers. Returns True on success."
+        "Use this method to add a new sticker to a set created by the bot. Emoji sticker sets can have up to 200 stickers. Other sticker sets can have up to 120 stickers. Returns True on success."
       ],
       "returns": [
         "Boolean"
@@ -4729,6 +4869,50 @@
           ],
           "required": true,
           "description": "File identifier of the sticker"
+        }
+      ]
+    },
+    "replaceStickerInSet": {
+      "name": "replaceStickerInSet",
+      "href": "https://core.telegram.org/bots/api#replacestickerinset",
+      "description": [
+        "Use this method to replace an existing sticker in a sticker set with a new one. The method is equivalent to calling deleteStickerFromSet, then addStickerToSet, then setStickerPositionInSet. Returns True on success."
+      ],
+      "returns": [
+        "Boolean"
+      ],
+      "fields": [
+        {
+          "name": "user_id",
+          "types": [
+            "Integer"
+          ],
+          "required": true,
+          "description": "User identifier of the sticker set owner"
+        },
+        {
+          "name": "name",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "Sticker set name"
+        },
+        {
+          "name": "old_sticker",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "File identifier of the replaced sticker"
+        },
+        {
+          "name": "sticker",
+          "types": [
+            "InputSticker"
+          ],
+          "required": true,
+          "description": "A JSON-serialized object with information about the added sticker. If exactly the same sticker had already been added to the set, then the set remains unchanged."
         }
       ]
     },
@@ -4878,6 +5062,14 @@
           ],
           "required": false,
           "description": "A .WEBP or .PNG image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a .TGS animation with a thumbnail up to 32 kilobytes in size (see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements), or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files. Animated and video sticker set thumbnails can't be uploaded via HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail."
+        },
+        {
+          "name": "format",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "Format of the thumbnail, must be one of \"static\" for a .WEBP or .PNG image, \"animated\" for a .TGS animation, or \"video\" for a WEBM video"
         }
       ]
     },
@@ -5539,6 +5731,14 @@
       ],
       "fields": [
         {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Unique identifier of the business connection on behalf of which the message will be sent"
+        },
+        {
           "name": "chat_id",
           "types": [
             "Integer"
@@ -5592,7 +5792,7 @@
             "InlineKeyboardMarkup"
           ],
           "required": false,
-          "description": "A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game."
+          "description": "A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game. Not supported for messages sent on behalf of a business account."
         }
       ]
     },
@@ -5758,6 +5958,38 @@
           ],
           "required": false,
           "description": "Optional. New version of a channel post that is known to the bot and was edited. This update may at times be triggered by changes to message fields that are either unavailable or not actively used by your bot."
+        },
+        {
+          "name": "business_connection",
+          "types": [
+            "BusinessConnection"
+          ],
+          "required": false,
+          "description": "Optional. The bot was connected to or disconnected from a business account, or a user edited an existing connection with the bot"
+        },
+        {
+          "name": "business_message",
+          "types": [
+            "Message"
+          ],
+          "required": false,
+          "description": "Optional. New non-service message from a connected business account"
+        },
+        {
+          "name": "edited_business_message",
+          "types": [
+            "Message"
+          ],
+          "required": false,
+          "description": "Optional. New version of a message from a connected business account"
+        },
+        {
+          "name": "deleted_business_messages",
+          "types": [
+            "BusinessMessagesDeleted"
+          ],
+          "required": false,
+          "description": "Optional. Messages were deleted from a connected business account"
         },
         {
           "name": "message_reaction",
@@ -6048,6 +6280,14 @@
           ],
           "required": false,
           "description": "Optional. True, if the bot supports inline queries. Returned only in getMe."
+        },
+        {
+          "name": "can_connect_to_business",
+          "types": [
+            "Boolean"
+          ],
+          "required": false,
+          "description": "Optional. True, if the bot can be connected to a Telegram Business account to receive its messages. Returned only in getMe."
         }
       ]
     },
@@ -6129,6 +6369,46 @@
           ],
           "required": false,
           "description": "Optional. If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in getChat."
+        },
+        {
+          "name": "birthdate",
+          "types": [
+            "Birthdate"
+          ],
+          "required": false,
+          "description": "Optional. For private chats, the date of birth of the user. Returned only in getChat."
+        },
+        {
+          "name": "business_intro",
+          "types": [
+            "BusinessIntro"
+          ],
+          "required": false,
+          "description": "Optional. For private chats with business accounts, the intro of the business. Returned only in getChat."
+        },
+        {
+          "name": "business_location",
+          "types": [
+            "BusinessLocation"
+          ],
+          "required": false,
+          "description": "Optional. For private chats with business accounts, the location of the business. Returned only in getChat."
+        },
+        {
+          "name": "business_opening_hours",
+          "types": [
+            "BusinessOpeningHours"
+          ],
+          "required": false,
+          "description": "Optional. For private chats with business accounts, the opening hours of the business. Returned only in getChat."
+        },
+        {
+          "name": "personal_chat",
+          "types": [
+            "Chat"
+          ],
+          "required": false,
+          "description": "Optional. For private chats, the personal channel of the user. Returned only in getChat."
         },
         {
           "name": "available_reactions",
@@ -6404,12 +6684,28 @@
           "description": "Optional. If the sender of the message boosted the chat, the number of boosts added by the user"
         },
         {
+          "name": "sender_business_bot",
+          "types": [
+            "User"
+          ],
+          "required": false,
+          "description": "Optional. The bot that actually sent the message on behalf of the business account. Available only for outgoing messages sent on behalf of the connected business account."
+        },
+        {
           "name": "date",
           "types": [
             "Integer"
           ],
           "required": true,
           "description": "Date the message was sent in Unix time. It is always a positive number, representing a valid date."
+        },
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Optional. Unique identifier of the business connection from which the message was received. If non-empty, the message belongs to a chat of the corresponding business account that is independent from any potential bot chat which might share the same identifier."
         },
         {
           "name": "chat",
@@ -6498,6 +6794,14 @@
           ],
           "required": false,
           "description": "Optional. True, if the message can't be forwarded"
+        },
+        {
+          "name": "is_from_offline",
+          "types": [
+            "Boolean"
+          ],
+          "required": false,
+          "description": "Optional. True, if the message was sent by an implicit action, for example, as an away or a greeting business message, or as a scheduled message"
         },
         {
           "name": "media_group_id",
@@ -7371,7 +7675,7 @@
             "String"
           ],
           "required": false,
-          "description": "Optional. If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format @channelusername)"
+          "description": "Optional. If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format @channelusername). Not supported for messages sent on behalf of a business account."
         },
         {
           "name": "allow_sending_without_reply",
@@ -7379,7 +7683,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. Pass True if the message should be sent even if the specified message to be replied to is not found; can be used only for replies in the same chat and forum topic."
+          "description": "Optional. Pass True if the message should be sent even if the specified message to be replied to is not found. Always False for replies in another chat or forum topic. Always True for messages sent on behalf of a business account."
         },
         {
           "name": "quote",
@@ -8633,6 +8937,55 @@
         "This object represents a service message about General forum topic unhidden in the chat. Currently holds no information."
       ]
     },
+    "SharedUser": {
+      "name": "SharedUser",
+      "href": "https://core.telegram.org/bots/api#shareduser",
+      "description": [
+        "This object contains information about a user that was shared with the bot using a KeyboardButtonRequestUser button."
+      ],
+      "fields": [
+        {
+          "name": "user_id",
+          "types": [
+            "Integer"
+          ],
+          "required": true,
+          "description": "Identifier of the shared user. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so 64-bit integers or double-precision float types are safe for storing these identifiers. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means."
+        },
+        {
+          "name": "first_name",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Optional. First name of the user, if the name was requested by the bot"
+        },
+        {
+          "name": "last_name",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Optional. Last name of the user, if the name was requested by the bot"
+        },
+        {
+          "name": "username",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Optional. Username of the user, if the username was requested by the bot"
+        },
+        {
+          "name": "photo",
+          "types": [
+            "Array of PhotoSize"
+          ],
+          "required": false,
+          "description": "Optional. Available sizes of the chat photo, if the photo was requested by the bot"
+        }
+      ]
+    },
     "UsersShared": {
       "name": "UsersShared",
       "href": "https://core.telegram.org/bots/api#usersshared",
@@ -8649,12 +9002,12 @@
           "description": "Identifier of the request"
         },
         {
-          "name": "user_ids",
+          "name": "users",
           "types": [
-            "Array of Integer"
+            "Array of SharedUser"
           ],
           "required": true,
-          "description": "Identifiers of the shared users. These numbers may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting them. But they have at most 52 significant bits, so 64-bit integers or double-precision float types are safe for storing these identifiers. The bot may not have access to the users and could be unable to use these identifiers, unless the users are already known to the bot by some other means."
+          "description": "Information about users shared with the bot."
         }
       ]
     },
@@ -8662,7 +9015,7 @@
       "name": "ChatShared",
       "href": "https://core.telegram.org/bots/api#chatshared",
       "description": [
-        "This object contains information about the chat whose identifier was shared with the bot using a KeyboardButtonRequestChat button."
+        "This object contains information about a chat that was shared with the bot using a KeyboardButtonRequestChat button."
       ],
       "fields": [
         {
@@ -8680,6 +9033,30 @@
           ],
           "required": true,
           "description": "Identifier of the shared chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the chat and could be unable to use this identifier, unless the chat is already known to the bot by some other means."
+        },
+        {
+          "name": "title",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Optional. Title of the chat, if the title was requested by the bot."
+        },
+        {
+          "name": "username",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Optional. Username of the chat, if the username was requested by the bot and available."
+        },
+        {
+          "name": "photo",
+          "types": [
+            "Array of PhotoSize"
+          ],
+          "required": false,
+          "description": "Optional. Available sizes of the chat photo, if the photo was requested by the bot"
         }
       ]
     },
@@ -9243,7 +9620,7 @@
       "name": "KeyboardButtonRequestUsers",
       "href": "https://core.telegram.org/bots/api#keyboardbuttonrequestusers",
       "description": [
-        "This object defines the criteria used to request suitable users. The identifiers of the selected users will be shared with the bot when the corresponding button is pressed. More about requesting users: https://core.telegram.org/bots/features#chat-and-user-selection"
+        "This object defines the criteria used to request suitable users. Information about the selected users will be shared with the bot when the corresponding button is pressed. More about requesting users: https://core.telegram.org/bots/features#chat-and-user-selection"
       ],
       "fields": [
         {
@@ -9277,6 +9654,30 @@
           ],
           "required": false,
           "description": "Optional. The maximum number of users to be selected; 1-10. Defaults to 1."
+        },
+        {
+          "name": "request_name",
+          "types": [
+            "Boolean"
+          ],
+          "required": false,
+          "description": "Optional. Pass True to request the users' first and last name"
+        },
+        {
+          "name": "request_username",
+          "types": [
+            "Boolean"
+          ],
+          "required": false,
+          "description": "Optional. Pass True to request the users' username"
+        },
+        {
+          "name": "request_photo",
+          "types": [
+            "Boolean"
+          ],
+          "required": false,
+          "description": "Optional. Pass True to request the users' photo"
         }
       ]
     },
@@ -9284,7 +9685,7 @@
       "name": "KeyboardButtonRequestChat",
       "href": "https://core.telegram.org/bots/api#keyboardbuttonrequestchat",
       "description": [
-        "This object defines the criteria used to request a suitable chat. The identifier of the selected chat will be shared with the bot when the corresponding button is pressed. More about requesting chats: https://core.telegram.org/bots/features#chat-and-user-selection"
+        "This object defines the criteria used to request a suitable chat. Information about the selected chat will be shared with the bot when the corresponding button is pressed. The bot will be granted requested rights in the \u0441hat if appropriate More about requesting chats: https://core.telegram.org/bots/features#chat-and-user-selection"
       ],
       "fields": [
         {
@@ -9350,6 +9751,30 @@
           ],
           "required": false,
           "description": "Optional. Pass True to request a chat with the bot as a member. Otherwise, no additional restrictions are applied."
+        },
+        {
+          "name": "request_title",
+          "types": [
+            "Boolean"
+          ],
+          "required": false,
+          "description": "Optional. Pass True to request the chat's title"
+        },
+        {
+          "name": "request_username",
+          "types": [
+            "Boolean"
+          ],
+          "required": false,
+          "description": "Optional. Pass True to request the chat's username"
+        },
+        {
+          "name": "request_photo",
+          "types": [
+            "Boolean"
+          ],
+          "required": false,
+          "description": "Optional. Pass True to request the chat's photo"
         }
       ]
     },
@@ -9913,7 +10338,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. True, if the administrator can post messages in the channel, or access channel statistics; channels only"
+          "description": "Optional. True, if the administrator can post messages in the channel, or access channel statistics; for channels only"
         },
         {
           "name": "can_edit_messages",
@@ -9921,7 +10346,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. True, if the administrator can edit messages of other users and can pin messages; channels only"
+          "description": "Optional. True, if the administrator can edit messages of other users and can pin messages; for channels only"
         },
         {
           "name": "can_pin_messages",
@@ -9929,7 +10354,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. True, if the user is allowed to pin messages; groups and supergroups only"
+          "description": "Optional. True, if the user is allowed to pin messages; for groups and supergroups only"
         },
         {
           "name": "can_manage_topics",
@@ -9937,7 +10362,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only"
+          "description": "Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only"
         }
       ]
     },
@@ -10196,7 +10621,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. True, if the administrator can post messages in the channel, or access channel statistics; channels only"
+          "description": "Optional. True, if the administrator can post messages in the channel, or access channel statistics; for channels only"
         },
         {
           "name": "can_edit_messages",
@@ -10204,7 +10629,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. True, if the administrator can edit messages of other users and can pin messages; channels only"
+          "description": "Optional. True, if the administrator can edit messages of other users and can pin messages; for channels only"
         },
         {
           "name": "can_pin_messages",
@@ -10212,7 +10637,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. True, if the user is allowed to pin messages; groups and supergroups only"
+          "description": "Optional. True, if the user is allowed to pin messages; for groups and supergroups only"
         },
         {
           "name": "can_manage_topics",
@@ -10220,7 +10645,7 @@
             "Boolean"
           ],
           "required": false,
-          "description": "Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only"
+          "description": "Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only"
         },
         {
           "name": "custom_title",
@@ -10658,6 +11083,132 @@
           ],
           "required": false,
           "description": "Optional. True, if the user is allowed to create forum topics. If omitted defaults to the value of can_pin_messages"
+        }
+      ]
+    },
+    "Birthdate": {
+      "name": "Birthdate",
+      "href": "https://core.telegram.org/bots/api#birthdate",
+      "fields": [
+        {
+          "name": "day",
+          "types": [
+            "Integer"
+          ],
+          "required": true,
+          "description": "Day of the user's birth; 1-31"
+        },
+        {
+          "name": "month",
+          "types": [
+            "Integer"
+          ],
+          "required": true,
+          "description": "Month of the user's birth; 1-12"
+        },
+        {
+          "name": "year",
+          "types": [
+            "Integer"
+          ],
+          "required": false,
+          "description": "Optional. Year of the user's birth"
+        }
+      ]
+    },
+    "BusinessIntro": {
+      "name": "BusinessIntro",
+      "href": "https://core.telegram.org/bots/api#businessintro",
+      "fields": [
+        {
+          "name": "title",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Optional. Title text of the business intro"
+        },
+        {
+          "name": "message",
+          "types": [
+            "String"
+          ],
+          "required": false,
+          "description": "Optional. Message text of the business intro"
+        },
+        {
+          "name": "sticker",
+          "types": [
+            "Sticker"
+          ],
+          "required": false,
+          "description": "Optional. Sticker of the business intro"
+        }
+      ]
+    },
+    "BusinessLocation": {
+      "name": "BusinessLocation",
+      "href": "https://core.telegram.org/bots/api#businesslocation",
+      "fields": [
+        {
+          "name": "address",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "Address of the business"
+        },
+        {
+          "name": "location",
+          "types": [
+            "Location"
+          ],
+          "required": false,
+          "description": "Optional. Location of the business"
+        }
+      ]
+    },
+    "BusinessOpeningHoursInterval": {
+      "name": "BusinessOpeningHoursInterval",
+      "href": "https://core.telegram.org/bots/api#businessopeninghoursinterval",
+      "fields": [
+        {
+          "name": "opening_minute",
+          "types": [
+            "Integer"
+          ],
+          "required": true,
+          "description": "The minute's sequence number in a week, starting on Monday, marking the start of the time interval during which the business is open; 0 - 7 24 60"
+        },
+        {
+          "name": "closing_minute",
+          "types": [
+            "Integer"
+          ],
+          "required": true,
+          "description": "The minute's sequence number in a week, starting on Monday, marking the end of the time interval during which the business is open; 0 - 8 24 60"
+        }
+      ]
+    },
+    "BusinessOpeningHours": {
+      "name": "BusinessOpeningHours",
+      "href": "https://core.telegram.org/bots/api#businessopeninghours",
+      "fields": [
+        {
+          "name": "time_zone_name",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "Unique name of the time zone for which the opening hours are defined"
+        },
+        {
+          "name": "opening_hours",
+          "types": [
+            "Array of BusinessOpeningHoursInterval"
+          ],
+          "required": true,
+          "description": "List of time intervals describing business opening hours"
         }
       ]
     },
@@ -11532,6 +12083,96 @@
         }
       ]
     },
+    "BusinessConnection": {
+      "name": "BusinessConnection",
+      "href": "https://core.telegram.org/bots/api#businessconnection",
+      "description": [
+        "Describes the connection of the bot with a business account."
+      ],
+      "fields": [
+        {
+          "name": "id",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "Unique identifier of the business connection"
+        },
+        {
+          "name": "user",
+          "types": [
+            "User"
+          ],
+          "required": true,
+          "description": "Business account user that created the business connection"
+        },
+        {
+          "name": "user_chat_id",
+          "types": [
+            "Integer"
+          ],
+          "required": true,
+          "description": "Identifier of a private chat with the user who created the business connection. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier."
+        },
+        {
+          "name": "date",
+          "types": [
+            "Integer"
+          ],
+          "required": true,
+          "description": "Date the connection was established in Unix time"
+        },
+        {
+          "name": "can_reply",
+          "types": [
+            "Boolean"
+          ],
+          "required": true,
+          "description": "True, if the bot can act on behalf of the business account in chats that were active in the last 24 hours"
+        },
+        {
+          "name": "is_enabled",
+          "types": [
+            "Boolean"
+          ],
+          "required": true,
+          "description": "True, if the connection is active"
+        }
+      ]
+    },
+    "BusinessMessagesDeleted": {
+      "name": "BusinessMessagesDeleted",
+      "href": "https://core.telegram.org/bots/api#businessmessagesdeleted",
+      "description": [
+        "This object is received when messages are deleted from a connected business account."
+      ],
+      "fields": [
+        {
+          "name": "business_connection_id",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "Unique identifier of the business connection"
+        },
+        {
+          "name": "chat",
+          "types": [
+            "Chat"
+          ],
+          "required": true,
+          "description": "Information about a chat in the business account. The bot may not have access to the chat or the corresponding user."
+        },
+        {
+          "name": "message_ids",
+          "types": [
+            "Array of Integer"
+          ],
+          "required": true,
+          "description": "A JSON-serialized list of identifiers of deleted messages in the chat of the business account"
+        }
+      ]
+    },
     "ResponseParameters": {
       "name": "ResponseParameters",
       "href": "https://core.telegram.org/bots/api#responseparameters",
@@ -12152,22 +12793,6 @@
           "description": "Type of stickers in the set, currently one of \"regular\", \"mask\", \"custom_emoji\""
         },
         {
-          "name": "is_animated",
-          "types": [
-            "Boolean"
-          ],
-          "required": true,
-          "description": "True, if the sticker set contains animated stickers"
-        },
-        {
-          "name": "is_video",
-          "types": [
-            "Boolean"
-          ],
-          "required": true,
-          "description": "True, if the sticker set contains video stickers"
-        },
-        {
           "name": "stickers",
           "types": [
             "Array of Sticker"
@@ -12241,6 +12866,14 @@
           ],
           "required": true,
           "description": "The added sticker. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, upload a new one using multipart/form-data, or pass \"attach://<file_attach_name>\" to upload a new one using multipart/form-data under <file_attach_name> name. Animated and video stickers can't be uploaded via HTTP URL. More information on Sending Files: https://core.telegram.org/bots/api#sending-files"
+        },
+        {
+          "name": "format",
+          "types": [
+            "String"
+          ],
+          "required": true,
+          "description": "Format of the added sticker, must be one of \"static\" for a .WEBP or .PNG image, \"animated\" for a .TGS animation, \"video\" for a WEBM video"
         },
         {
           "name": "emoji_list",
@@ -15321,7 +15954,7 @@
             "String"
           ],
           "required": false,
-          "description": "Optional. Base64-encoded encrypted Telegram Passport element data provided by the user, available for \"personal_details\", \"passport\", \"driver_license\", \"identity_card\", \"internal_passport\" and \"address\" types. Can be decrypted and verified using the accompanying EncryptedCredentials."
+          "description": "Optional. Base64-encoded encrypted Telegram Passport element data provided by the user; available only for \"personal_details\", \"passport\", \"driver_license\", \"identity_card\", \"internal_passport\" and \"address\" types. Can be decrypted and verified using the accompanying EncryptedCredentials."
         },
         {
           "name": "phone_number",
@@ -15329,7 +15962,7 @@
             "String"
           ],
           "required": false,
-          "description": "Optional. User's verified phone number, available only for \"phone_number\" type"
+          "description": "Optional. User's verified phone number; available only for \"phone_number\" type"
         },
         {
           "name": "email",
@@ -15337,7 +15970,7 @@
             "String"
           ],
           "required": false,
-          "description": "Optional. User's verified email address, available only for \"email\" type"
+          "description": "Optional. User's verified email address; available only for \"email\" type"
         },
         {
           "name": "files",
@@ -15345,7 +15978,7 @@
             "Array of PassportFile"
           ],
           "required": false,
-          "description": "Optional. Array of encrypted files with documents provided by the user, available for \"utility_bill\", \"bank_statement\", \"rental_agreement\", \"passport_registration\" and \"temporary_registration\" types. Files can be decrypted and verified using the accompanying EncryptedCredentials."
+          "description": "Optional. Array of encrypted files with documents provided by the user; available only for \"utility_bill\", \"bank_statement\", \"rental_agreement\", \"passport_registration\" and \"temporary_registration\" types. Files can be decrypted and verified using the accompanying EncryptedCredentials."
         },
         {
           "name": "front_side",
@@ -15353,7 +15986,7 @@
             "PassportFile"
           ],
           "required": false,
-          "description": "Optional. Encrypted file with the front side of the document, provided by the user. Available for \"passport\", \"driver_license\", \"identity_card\" and \"internal_passport\". The file can be decrypted and verified using the accompanying EncryptedCredentials."
+          "description": "Optional. Encrypted file with the front side of the document, provided by the user; available only for \"passport\", \"driver_license\", \"identity_card\" and \"internal_passport\". The file can be decrypted and verified using the accompanying EncryptedCredentials."
         },
         {
           "name": "reverse_side",
@@ -15361,7 +15994,7 @@
             "PassportFile"
           ],
           "required": false,
-          "description": "Optional. Encrypted file with the reverse side of the document, provided by the user. Available for \"driver_license\" and \"identity_card\". The file can be decrypted and verified using the accompanying EncryptedCredentials."
+          "description": "Optional. Encrypted file with the reverse side of the document, provided by the user; available only for \"driver_license\" and \"identity_card\". The file can be decrypted and verified using the accompanying EncryptedCredentials."
         },
         {
           "name": "selfie",
@@ -15369,7 +16002,7 @@
             "PassportFile"
           ],
           "required": false,
-          "description": "Optional. Encrypted file with the selfie of the user holding a document, provided by the user; available for \"passport\", \"driver_license\", \"identity_card\" and \"internal_passport\". The file can be decrypted and verified using the accompanying EncryptedCredentials."
+          "description": "Optional. Encrypted file with the selfie of the user holding a document, provided by the user; available if requested for \"passport\", \"driver_license\", \"identity_card\" and \"internal_passport\". The file can be decrypted and verified using the accompanying EncryptedCredentials."
         },
         {
           "name": "translation",
@@ -15377,7 +16010,7 @@
             "Array of PassportFile"
           ],
           "required": false,
-          "description": "Optional. Array of encrypted files with translated versions of documents provided by the user. Available if requested for \"passport\", \"driver_license\", \"identity_card\", \"internal_passport\", \"utility_bill\", \"bank_statement\", \"rental_agreement\", \"passport_registration\" and \"temporary_registration\" types. Files can be decrypted and verified using the accompanying EncryptedCredentials."
+          "description": "Optional. Array of encrypted files with translated versions of documents provided by the user; available if requested for \"passport\", \"driver_license\", \"identity_card\", \"internal_passport\", \"utility_bill\", \"bank_statement\", \"rental_agreement\", \"passport_registration\" and \"temporary_registration\" types. Files can be decrypted and verified using the accompanying EncryptedCredentials."
         },
         {
           "name": "hash",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 ktor = "2.3.9"
-logging = "5.4.0"
+logging = "2.0.3"
+logback = "1.5.3"
+
 datetime = "0.5.0"
 serialization = "1.6.3"
 stately = "2.0.7"
@@ -31,7 +33,8 @@ ktor-client-winhttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "k
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 
 # logging
-logging = { module = "com.soywiz.korge:korlibs-logger", version.ref = "logging" }
+logging = { module = "co.touchlab:kermit", version.ref = "logging" }
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
 kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlin-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }

--- a/ksp/src/jvmMain/kotlin/eu/vendeli/ksp/HelperUtils.kt
+++ b/ksp/src/jvmMain/kotlin/eu/vendeli/ksp/HelperUtils.kt
@@ -22,6 +22,8 @@ import com.squareup.kotlinpoet.asTypeName
 import eu.vendeli.tgbot.TelegramBot
 import eu.vendeli.tgbot.interfaces.Autowiring
 import eu.vendeli.tgbot.types.User
+import eu.vendeli.tgbot.types.internal.BusinessConnectionUpdate
+import eu.vendeli.tgbot.types.internal.BusinessMessageUpdate
 import eu.vendeli.tgbot.types.internal.CallbackQueryUpdate
 import eu.vendeli.tgbot.types.internal.ChainLink
 import eu.vendeli.tgbot.types.internal.ChannelPostUpdate
@@ -29,6 +31,8 @@ import eu.vendeli.tgbot.types.internal.ChatBoostUpdate
 import eu.vendeli.tgbot.types.internal.ChatJoinRequestUpdate
 import eu.vendeli.tgbot.types.internal.ChatMemberUpdate
 import eu.vendeli.tgbot.types.internal.ChosenInlineResultUpdate
+import eu.vendeli.tgbot.types.internal.DeletedBusinessMessagesUpdate
+import eu.vendeli.tgbot.types.internal.EditedBusinessMessageUpdate
 import eu.vendeli.tgbot.types.internal.EditedChannelPostUpdate
 import eu.vendeli.tgbot.types.internal.EditedMessageUpdate
 import eu.vendeli.tgbot.types.internal.InlineQueryUpdate
@@ -86,6 +90,10 @@ internal val chatMemberUpdateClass = ChatMemberUpdate::class.asTypeName()
 internal val chatJoinRequestUpdateClass = ChatJoinRequestUpdate::class.asTypeName()
 internal val chatBoostUpdateClass = ChatBoostUpdate::class.asTypeName()
 internal val removedChatBoostUpdateClass = RemovedChatBoostUpdate::class.asTypeName()
+internal val businessConnectionUpdateClass = BusinessConnectionUpdate::class.asTypeName()
+internal val businessMessageUpdateClass = BusinessMessageUpdate::class.asTypeName()
+internal val editedBusinessMessageClass = EditedBusinessMessageUpdate::class.asTypeName()
+internal val deletedBusinessMessagesClass = DeletedBusinessMessagesUpdate::class.asTypeName()
 
 internal val callbackQueryList = listOf(UpdateType.CALLBACK_QUERY)
 internal val messageList = listOf(UpdateType.MESSAGE)

--- a/ksp/src/jvmMain/kotlin/eu/vendeli/ksp/InvocationLambdaBuilder.kt
+++ b/ksp/src/jvmMain/kotlin/eu/vendeli/ksp/InvocationLambdaBuilder.kt
@@ -72,9 +72,9 @@ internal fun FileBuilder.buildInvocationLambdaCodeBlock(
                 }?.let { i ->
                     i.arguments.first { a -> a.name?.asString() == "name" }.value as? String
                 } ?: parameter.name!!.getShortName()
-                ).let {
-                    "parameters[\"$it\"]"
-                }
+            ).let {
+                "parameters[\"$it\"]"
+            }
             val typeName = parameter.type.toTypeName().copy(false)
             val nullabilityMark = if (parameter.type.toTypeName().isNullable) "" else "!!"
 

--- a/ksp/src/jvmMain/kotlin/eu/vendeli/ksp/InvocationLambdaBuilder.kt
+++ b/ksp/src/jvmMain/kotlin/eu/vendeli/ksp/InvocationLambdaBuilder.kt
@@ -14,12 +14,16 @@ import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.buildCodeBlock
 import com.squareup.kotlinpoet.ksp.toTypeName
+import eu.vendeli.tgbot.types.internal.BusinessConnectionUpdate
+import eu.vendeli.tgbot.types.internal.BusinessMessageUpdate
 import eu.vendeli.tgbot.types.internal.CallbackQueryUpdate
 import eu.vendeli.tgbot.types.internal.ChannelPostUpdate
 import eu.vendeli.tgbot.types.internal.ChatBoostUpdate
 import eu.vendeli.tgbot.types.internal.ChatJoinRequestUpdate
 import eu.vendeli.tgbot.types.internal.ChatMemberUpdate
 import eu.vendeli.tgbot.types.internal.ChosenInlineResultUpdate
+import eu.vendeli.tgbot.types.internal.DeletedBusinessMessagesUpdate
+import eu.vendeli.tgbot.types.internal.EditedBusinessMessageUpdate
 import eu.vendeli.tgbot.types.internal.EditedChannelPostUpdate
 import eu.vendeli.tgbot.types.internal.EditedMessageUpdate
 import eu.vendeli.tgbot.types.internal.InlineQueryUpdate
@@ -68,9 +72,9 @@ internal fun FileBuilder.buildInvocationLambdaCodeBlock(
                 }?.let { i ->
                     i.arguments.first { a -> a.name?.asString() == "name" }.value as? String
                 } ?: parameter.name!!.getShortName()
-            ).let {
-                "parameters[\"$it\"]"
-            }
+                ).let {
+                    "parameters[\"$it\"]"
+                }
             val typeName = parameter.type.toTypeName().copy(false)
             val nullabilityMark = if (parameter.type.toTypeName().isNullable) "" else "!!"
 
@@ -103,6 +107,10 @@ internal fun FileBuilder.buildInvocationLambdaCodeBlock(
                 chatJoinRequestUpdateClass -> addUpdate(ChatJoinRequestUpdate::class, nullabilityMark)
                 chatBoostUpdateClass -> addUpdate(ChatBoostUpdate::class, nullabilityMark)
                 removedChatBoostUpdateClass -> addUpdate(RemovedChatBoostUpdate::class, nullabilityMark)
+                businessConnectionUpdateClass -> addUpdate(BusinessConnectionUpdate::class, nullabilityMark)
+                businessMessageUpdateClass -> addUpdate(BusinessMessageUpdate::class, nullabilityMark)
+                editedBusinessMessageClass -> addUpdate(EditedBusinessMessageUpdate::class, nullabilityMark)
+                deletedBusinessMessagesClass -> addUpdate(DeletedBusinessMessagesUpdate::class, nullabilityMark)
 
                 in injectableTypes.keys -> {
                     val type = injectableTypes[typeName]!!

--- a/ktgram-utils/src/commonMain/kotlin/eu/vendeli/ktgram/extutils/TelegramBotSc.kt
+++ b/ktgram-utils/src/commonMain/kotlin/eu/vendeli/ktgram/extutils/TelegramBotSc.kt
@@ -3,26 +3,45 @@
 package eu.vendeli.ktgram.extutils
 
 import eu.vendeli.tgbot.TelegramBot
+import eu.vendeli.tgbot.api.answer.answerInlineQuery
 import eu.vendeli.tgbot.api.answer.answerPreCheckoutQuery
+import eu.vendeli.tgbot.api.answer.answerShippingQuery
+import eu.vendeli.tgbot.api.answer.answerWebAppQuery
+import eu.vendeli.tgbot.api.botactions.close
+import eu.vendeli.tgbot.api.botactions.createInvoiceLink
+import eu.vendeli.tgbot.api.botactions.deleteMyCommands
 import eu.vendeli.tgbot.api.botactions.deleteWebhook
+import eu.vendeli.tgbot.api.botactions.getBusinessConnection
 import eu.vendeli.tgbot.api.botactions.getMe
 import eu.vendeli.tgbot.api.botactions.getMyCommands
 import eu.vendeli.tgbot.api.botactions.getMyDefaultAdministratorRights
 import eu.vendeli.tgbot.api.botactions.getMyDescription
+import eu.vendeli.tgbot.api.botactions.getMyName
+import eu.vendeli.tgbot.api.botactions.getMyShortDescription
 import eu.vendeli.tgbot.api.botactions.getUpdates
 import eu.vendeli.tgbot.api.botactions.getWebhookInfo
+import eu.vendeli.tgbot.api.botactions.logOut
+import eu.vendeli.tgbot.api.botactions.setMyCommands
 import eu.vendeli.tgbot.api.botactions.setMyDefaultAdministratorRights
+import eu.vendeli.tgbot.api.botactions.setMyDescription
+import eu.vendeli.tgbot.api.botactions.setMyName
+import eu.vendeli.tgbot.api.botactions.setMyShortDescription
 import eu.vendeli.tgbot.api.chat.approveChatJoinRequest
 import eu.vendeli.tgbot.api.chat.banChatMember
+import eu.vendeli.tgbot.api.chat.banChatSenderChat
+import eu.vendeli.tgbot.api.chat.chatAction
 import eu.vendeli.tgbot.api.chat.createChatInviteLink
 import eu.vendeli.tgbot.api.chat.declineChatJoinRequest
 import eu.vendeli.tgbot.api.chat.deleteChatPhoto
 import eu.vendeli.tgbot.api.chat.deleteChatStickerSet
 import eu.vendeli.tgbot.api.chat.editChatInviteLink
+import eu.vendeli.tgbot.api.chat.exportChatInviteLink
 import eu.vendeli.tgbot.api.chat.getChat
 import eu.vendeli.tgbot.api.chat.getChatAdministrators
+import eu.vendeli.tgbot.api.chat.getChatMember
 import eu.vendeli.tgbot.api.chat.getChatMemberCount
 import eu.vendeli.tgbot.api.chat.getChatMenuButton
+import eu.vendeli.tgbot.api.chat.leaveChat
 import eu.vendeli.tgbot.api.chat.pinChatMessage
 import eu.vendeli.tgbot.api.chat.promoteChatMember
 import eu.vendeli.tgbot.api.chat.restrictChatMember
@@ -36,15 +55,24 @@ import eu.vendeli.tgbot.api.chat.setChatStickerSet
 import eu.vendeli.tgbot.api.chat.setChatTitle
 import eu.vendeli.tgbot.api.chat.unbanChatMember
 import eu.vendeli.tgbot.api.chat.unbanChatSenderChat
+import eu.vendeli.tgbot.api.chat.unpinAllChatMessages
+import eu.vendeli.tgbot.api.chat.unpinChatMessage
 import eu.vendeli.tgbot.api.contact
+import eu.vendeli.tgbot.api.forum.closeForumTopic
 import eu.vendeli.tgbot.api.forum.closeGeneralForumTopic
+import eu.vendeli.tgbot.api.forum.createForumTopic
+import eu.vendeli.tgbot.api.forum.deleteForumTopic
+import eu.vendeli.tgbot.api.forum.editForumTopic
 import eu.vendeli.tgbot.api.forum.editGeneralForumTopic
 import eu.vendeli.tgbot.api.forum.getForumTopicIconStickers
 import eu.vendeli.tgbot.api.forum.hideGeneralForumTopic
+import eu.vendeli.tgbot.api.forum.reopenForumTopic
+import eu.vendeli.tgbot.api.forum.reopenGeneralForumTopic
 import eu.vendeli.tgbot.api.forum.unhideGeneralForumTopic
 import eu.vendeli.tgbot.api.forum.unpinAllForumTopicMessages
 import eu.vendeli.tgbot.api.forum.unpinAllGeneralForumTopicMessages
 import eu.vendeli.tgbot.api.getFile
+import eu.vendeli.tgbot.api.getGameHighScores
 import eu.vendeli.tgbot.api.getUserChatBoosts
 import eu.vendeli.tgbot.api.getUserProfilePhotos
 import eu.vendeli.tgbot.api.invoice
@@ -55,14 +83,23 @@ import eu.vendeli.tgbot.api.media.sendMediaGroup
 import eu.vendeli.tgbot.api.media.sticker
 import eu.vendeli.tgbot.api.media.video
 import eu.vendeli.tgbot.api.media.videoNote
+import eu.vendeli.tgbot.api.media.voice
+import eu.vendeli.tgbot.api.message.copyMessage
+import eu.vendeli.tgbot.api.message.copyMessages
 import eu.vendeli.tgbot.api.message.deleteMessage
 import eu.vendeli.tgbot.api.message.deleteMessages
 import eu.vendeli.tgbot.api.message.editMessageCaption
+import eu.vendeli.tgbot.api.message.editMessageLiveLocation
+import eu.vendeli.tgbot.api.message.editMessageMedia
 import eu.vendeli.tgbot.api.message.editMessageReplyMarkup
 import eu.vendeli.tgbot.api.message.editMessageText
+import eu.vendeli.tgbot.api.message.forwardMessages
+import eu.vendeli.tgbot.api.message.message
+import eu.vendeli.tgbot.api.poll
 import eu.vendeli.tgbot.api.sendDice
 import eu.vendeli.tgbot.api.sendGame
 import eu.vendeli.tgbot.api.sendLocation
+import eu.vendeli.tgbot.api.setGameScore
 import eu.vendeli.tgbot.api.setMessageReaction
 import eu.vendeli.tgbot.api.setPassportDataErrors
 import eu.vendeli.tgbot.api.stickerset.addStickerToSet
@@ -71,7 +108,7 @@ import eu.vendeli.tgbot.api.stickerset.deleteStickerFromSet
 import eu.vendeli.tgbot.api.stickerset.deleteStickerSet
 import eu.vendeli.tgbot.api.stickerset.getCustomEmojiStickers
 import eu.vendeli.tgbot.api.stickerset.getStickerSet
-import eu.vendeli.tgbot.api.stickerset.setCustomEmojiStickerSetThumbnail
+import eu.vendeli.tgbot.api.stickerset.replaceStickerInSet
 import eu.vendeli.tgbot.api.stickerset.setStickerEmojiList
 import eu.vendeli.tgbot.api.stickerset.setStickerKeywords
 import eu.vendeli.tgbot.api.stickerset.setStickerMaskPosition
@@ -80,12 +117,18 @@ import eu.vendeli.tgbot.api.stickerset.setStickerSetThumbnail
 import eu.vendeli.tgbot.api.stickerset.setStickerSetTitle
 import eu.vendeli.tgbot.api.stickerset.uploadStickerFile
 import eu.vendeli.tgbot.api.stopMessageLiveLocation
+import eu.vendeli.tgbot.api.stopPoll
 import eu.vendeli.tgbot.api.venue
 import eu.vendeli.tgbot.types.ReactionType
+import eu.vendeli.tgbot.types.bot.BotCommand
 import eu.vendeli.tgbot.types.bot.BotCommandScope
+import eu.vendeli.tgbot.types.chat.ChatAction
 import eu.vendeli.tgbot.types.chat.ChatAdministratorRights
 import eu.vendeli.tgbot.types.chat.ChatPermissions
+import eu.vendeli.tgbot.types.forum.IconColor
+import eu.vendeli.tgbot.types.inline.InlineQueryResult
 import eu.vendeli.tgbot.types.internal.Currency
+import eu.vendeli.tgbot.types.internal.Identifier
 import eu.vendeli.tgbot.types.internal.ImplicitFile
 import eu.vendeli.tgbot.types.internal.InputFile
 import eu.vendeli.tgbot.types.keyboard.MenuButton
@@ -95,266 +138,138 @@ import eu.vendeli.tgbot.types.media.MaskPosition
 import eu.vendeli.tgbot.types.media.StickerFormat
 import eu.vendeli.tgbot.types.passport.PassportElementError
 import eu.vendeli.tgbot.types.payment.LabeledPrice
+import eu.vendeli.tgbot.types.payment.ShippingOption
 import kotlinx.datetime.Instant
 
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setStickerPositionInSetSc(sticker: String, position: Int) =
-    setStickerPositionInSet(sticker, position)
-
+inline fun TelegramBot.forwardMessagesSc(fromChatId: Identifier, messageIds: List<Long>) = forwardMessages(fromChatId,  messageIds)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getMyDefaultAdministratorRightsSc(forChannel: Boolean? = null) =
-    getMyDefaultAdministratorRights(forChannel)
-
+inline fun TelegramBot.getMyDefaultAdministratorRightsSc(forChannel: Boolean? = null) = getMyDefaultAdministratorRights(forChannel)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.unbanChatMemberSc(userId: Long, onlyIfBanned: Boolean? = null) =
-    unbanChatMember(userId, onlyIfBanned)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.editMessageCaptionSc(messageId: Long) = editMessageCaption(messageId)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.revokeChatInviteLinkSc(inviteLink: String) = revokeChatInviteLink(inviteLink)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getForumTopicIconStickersSc() = getForumTopicIconStickers()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getChatMenuButtonSc() = getChatMenuButton()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.deleteMessagesSc(messageIds: List<Long>) = deleteMessages(messageIds)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setChatDescriptionSc(title: String? = null) = setChatDescription(title)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.pinChatMessageSc(messageId: Long, disableNotification: Boolean? = null) =
-    pinChatMessage(messageId, disableNotification)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.stopMessageLiveLocationSc(messageId: Long) = stopMessageLiveLocation(messageId)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.deleteMessageSc(messageId: Long) = deleteMessage(messageId)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.sendGameSc(gameShortName: String) = sendGame(gameShortName)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setMessageReactionSc(
-    messageId: Long,
-    reaction: List<ReactionType>? = null,
-    isBig: Boolean? = null,
-) = setMessageReaction(messageId, reaction, isBig)
-
+inline fun TelegramBot.banChatSenderChatSc(senderChatId: Long) = banChatSenderChat(senderChatId)
 @Suppress("NOTHING_TO_INLINE")
 inline fun TelegramBot.getMyDescriptionSc(languageCode: String? = null) = getMyDescription(languageCode)
-
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.declineChatJoinRequestSc(userId: Long) = declineChatJoinRequest(userId)
-
+inline fun TelegramBot.leaveChatSc() = leaveChat()
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.documentSc(file: ImplicitFile) = document(file)
-
+inline fun TelegramBot.getChatMenuButtonSc() = getChatMenuButton()
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.promoteChatMemberSc(userId: Long) = promoteChatMember(userId)
-
+inline fun TelegramBot.getBusinessConnectionSc(businessConnectionId: String) = getBusinessConnection(businessConnectionId)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.restrictChatMemberSc(
-    userId: Long,
-    untilDate: Instant? = null,
-    useIndependentChatPermissions: Boolean? = null,
-    chatPermissions: ChatPermissions.() -> Unit,
-) = restrictChatMember(
-    userId,
-    untilDate,
-    useIndependentChatPermissions,
-    chatPermissions,
-)
-
+inline fun TelegramBot.copyMessagesSc(fromChatId: Identifier, messageIds: List<Long>) = copyMessages(fromChatId,  messageIds)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.animationSc(file: ImplicitFile) = animation(file)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.createNewStickerSetSc(
-    name: String,
-    title: String,
-    stickerFormat: StickerFormat,
-    stickers: List<InputSticker>,
-) = createNewStickerSet(
-    name,
-    title,
-    stickerFormat,
-    stickers,
-)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getChatSc() = getChat()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.banChatMemberSc(userId: Long, untilDate: Instant? = null, revokeMessages: Boolean? = null) =
-    banChatMember(userId, untilDate, revokeMessages)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.editMessageReplyMarkupSc() = editMessageReplyMarkup()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.editChatInviteLinkSc(inviteLink: String) = editChatInviteLink(inviteLink)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.stickerSc(file: ImplicitFile) = sticker(file)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setChatPermissionsSc(
-    permissions: ChatPermissions,
-    useIndependentChatPermissions: Boolean? = null,
-) = setChatPermissions(
-    permissions,
-    useIndependentChatPermissions,
-)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.videoSc(file: ImplicitFile) = video(file)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.approveChatJoinRequestSc(userId: Long) = approveChatJoinRequest(userId)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setChatStickerSetSc(stickerSetName: String) = setChatStickerSet(stickerSetName)
-
+inline fun TelegramBot.editForumTopicSc(messageThreadId: Int, name: String? = null, iconCustomEmojiId: String? = null) = editForumTopic(messageThreadId,  name,  iconCustomEmojiId)
 @Suppress("NOTHING_TO_INLINE")
 inline fun TelegramBot.setChatMenuButtonSc(menuButton: MenuButton) = setChatMenuButton(menuButton)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getUpdatesSc() = getUpdates()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getCustomEmojiStickersSc(customEmojiIds: List<String>) = getCustomEmojiStickers(customEmojiIds)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getStickerSetSc(name: String) = getStickerSet(name)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.editMessageTextSc(messageId: Long, block: () -> String) = editMessageText(messageId,  block)
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.deleteChatStickerSetSc() = deleteChatStickerSet()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getMyCommandsSc(languageCode: String? = null, scope: BotCommandScope? = null) =
-    getMyCommands(languageCode, scope)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.videoNoteSc(file: ImplicitFile) = videoNote(file)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getChatMemberCountSc() = getChatMemberCount()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.photoSc(file: ImplicitFile) = photo(file)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setStickerKeywordsSc(sticker: String, keywords: List<String>? = null) =
-    setStickerKeywords(sticker, keywords)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.deleteStickerSetSc(name: String) = deleteStickerSet(name)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.sendMediaGroupSc(media: List<InputMedia>) = sendMediaGroup(media)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.addStickerToSetSc(name: String, input: InputSticker) = addStickerToSet(name, input)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.hideGeneralForumTopicSc() = hideGeneralForumTopic()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.contactSc(firstName: String, phoneNumber: String) = contact(firstName, phoneNumber)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setCustomEmojiStickerSetThumbnailSc(name: String, customEmojiId: String? = null) =
-    setCustomEmojiStickerSetThumbnail(name, customEmojiId)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.unbanChatSenderChatSc(senderChatId: Long) = unbanChatSenderChat(senderChatId)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setStickerSetThumbnailSc(name: String, thumbnail: ImplicitFile? = null) =
-    setStickerSetThumbnail(name, thumbnail)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.createChatInviteLinkSc() = createChatInviteLink()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.sendLocationSc(latitude: Float, longitude: Float) = sendLocation(latitude, longitude)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.deleteChatPhotoSc() = deleteChatPhoto()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setPassportDataErrorsSc(userId: Long, errors: List<PassportElementError>) =
-    setPassportDataErrors(userId, errors)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getChatAdministratorsSc() = getChatAdministrators()
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setStickerSetTitleSc(name: String, title: String) = setStickerSetTitle(name, title)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setStickerEmojiListSc(sticker: String, emojiList: List<String>) =
-    setStickerEmojiList(sticker, emojiList)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setChatAdministratorCustomTitleSc(userId: Long, customTitle: String) =
-    setChatAdministratorCustomTitle(userId, customTitle)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getFileSc(fileId: String) = getFile(fileId)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setStickerMaskPositionSc(sticker: String, maskPosition: MaskPosition? = null) =
-    setStickerMaskPosition(sticker, maskPosition)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setChatTitleSc(title: String) = setChatTitle(title)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setChatPhotoSc(file: ImplicitFile) = setChatPhoto(file)
-
 @Suppress("NOTHING_TO_INLINE")
 inline fun TelegramBot.unpinAllForumTopicMessagesSc(messageThreadId: Int) = unpinAllForumTopicMessages(messageThreadId)
-
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.editGeneralForumTopicSc(name: String) = editGeneralForumTopic(name)
-
+inline fun TelegramBot.setChatDescriptionSc(title: String? = null) = setChatDescription(title)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.uploadStickerFileSc(sticker: InputFile, stickerFormat: StickerFormat) =
-    uploadStickerFile(sticker, stickerFormat)
-
+inline fun TelegramBot.animationSc(file: ImplicitFile) = animation(file)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.deleteStickerFromSetSc(sticker: String) = deleteStickerFromSet(sticker)
-
+inline fun TelegramBot.getChatSc() = getChat()
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.setMyDefaultAdministratorRightsSc(
-    rights: ChatAdministratorRights? = null,
-    forChannel: Boolean? = null,
-) = setMyDefaultAdministratorRights(rights, forChannel)
-
+inline fun TelegramBot.replaceStickerInSetSc(name: String) = replaceStickerInSet(name)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.venueSc(latitude: Float, longitude: Float, title: String, address: String) =
-    venue(latitude, longitude, title, address)
-
+inline fun TelegramBot.answerInlineQuerySc(inlineQueryId: String, results: List<InlineQueryResult>) = answerInlineQuery(inlineQueryId,  results)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.answerPreCheckoutQuerySc(
-    preCheckoutQueryId: String,
-    ok: Boolean = true,
-    errorMessage: String? = null,
-) = answerPreCheckoutQuery(preCheckoutQueryId, ok, errorMessage)
-
+inline fun TelegramBot.getFileSc(fileId: String) = getFile(fileId)
 @Suppress("NOTHING_TO_INLINE")
 inline fun TelegramBot.unpinAllGeneralForumTopicMessagesSc() = unpinAllGeneralForumTopicMessages()
-
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.photoSc(file: ImplicitFile) = photo(file)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.createInvoiceLinkSc(
+    title: String,
+    description: String,
+    payload: String,
+    providerToken: String,
+    currency: Currency,
+    prices: List<LabeledPrice>,
+) = createInvoiceLink(
+    title, 
+    description, 
+    payload, 
+    providerToken, 
+    currency, 
+    prices, )
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.approveChatJoinRequestSc(userId: Long) = approveChatJoinRequest(userId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.videoNoteSc(file: ImplicitFile) = videoNote(file)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.deleteChatPhotoSc() = deleteChatPhoto()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getUpdatesSc() = getUpdates()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setMyShortDescriptionSc(
+    description: String? = null,
+    languageCode: String? = null,
+) = setMyShortDescription(
+    description, 
+    languageCode, )
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.deleteChatStickerSetSc() = deleteChatStickerSet()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getForumTopicIconStickersSc() = getForumTopicIconStickers()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.unpinAllChatMessagesSc() = unpinAllChatMessages()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getChatMemberCountSc() = getChatMemberCount()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getCustomEmojiStickersSc(customEmojiIds: List<String>) = getCustomEmojiStickers(customEmojiIds)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.messageSc(text: String) = message(text)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.revokeChatInviteLinkSc(inviteLink: String) = revokeChatInviteLink(inviteLink)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.deleteStickerFromSetSc(sticker: String) = deleteStickerFromSet(sticker)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.stopPollSc(messageId: Long) = stopPoll(messageId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setChatStickerSetSc(stickerSetName: String) = setChatStickerSet(stickerSetName)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.unhideGeneralForumTopicSc() = unhideGeneralForumTopic()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getMyCommandsSc(languageCode: String? = null, scope: BotCommandScope? = null) = getMyCommands(languageCode,  scope)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.documentSc(file: ImplicitFile) = document(file)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.logOutSc() = logOut()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.reopenGeneralForumTopicSc() = reopenGeneralForumTopic()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.unbanChatSenderChatSc(senderChatId: Long) = unbanChatSenderChat(senderChatId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.deleteStickerSetSc(name: String) = deleteStickerSet(name)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.sendMediaGroupSc(media: List<InputMedia>) = sendMediaGroup(media)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.declineChatJoinRequestSc(userId: Long) = declineChatJoinRequest(userId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.deleteMessagesSc(messageIds: List<Long>) = deleteMessages(messageIds)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.editChatInviteLinkSc(inviteLink: String) = editChatInviteLink(inviteLink)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setPassportDataErrorsSc(userId: Long, errors: List<PassportElementError>) = setPassportDataErrors(userId,  errors)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.answerShippingQuerySc(
+    shippingQueryId: String,
+    ok: Boolean = true,
+    shippingOptions: List<ShippingOption>? = null,
+    errorMessage: String? = null,
+) = answerShippingQuery(
+    shippingQueryId, 
+    ok, 
+    shippingOptions, 
+    errorMessage, )
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.editGeneralForumTopicSc(name: String) = editGeneralForumTopic(name)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.unpinChatMessageSc(messageId: Long) = unpinChatMessage(messageId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.hideGeneralForumTopicSc() = hideGeneralForumTopic()
 @Suppress("NOTHING_TO_INLINE")
 inline fun TelegramBot.invoiceSc(
     title: String,
@@ -364,35 +279,167 @@ inline fun TelegramBot.invoiceSc(
     currency: Currency,
     prices: List<LabeledPrice>,
 ) = invoice(
-    title,
-    description,
-    payload,
-    providerToken,
-    currency,
-    prices,
-)
-
+    title, 
+    description, 
+    payload, 
+    providerToken, 
+    currency, 
+    prices, )
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getUserProfilePhotosSc(userId: Long, offset: Int? = null, limit: Int? = null) =
-    getUserProfilePhotos(userId, offset, limit)
-
+inline fun TelegramBot.unbanChatMemberSc(userId: Long, onlyIfBanned: Boolean? = null) = unbanChatMember(userId,  onlyIfBanned)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.unhideGeneralForumTopicSc() = unhideGeneralForumTopic()
-
+inline fun TelegramBot.contactSc(firstName: String, phoneNumber: String) = contact(firstName,  phoneNumber)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.closeGeneralForumTopicSc() = closeGeneralForumTopic()
-
+inline fun TelegramBot.closeSc() = close()
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.sendDiceSc(emoji: String? = null) = sendDice(emoji)
-
+inline fun TelegramBot.editMessageCaptionSc(messageId: Long) = editMessageCaption(messageId)
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.getMeSc() = getMe()
-
+inline fun TelegramBot.setStickerPositionInSetSc(sticker: String, position: Int) = setStickerPositionInSet(sticker,  position)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.restrictChatMemberSc(
+    userId: Long,
+    untilDate: Instant? = null,
+    useIndependentChatPermissions: Boolean? = null,
+    chatPermissions: ChatPermissions.() -> Unit) = restrictChatMember(
+    userId, 
+    untilDate, 
+    useIndependentChatPermissions, 
+    chatPermissions)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.editMessageLiveLocationSc(messageId: Long, latitude: Float, longitude: Float) = editMessageLiveLocation(messageId,  latitude,  longitude)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getChatAdministratorsSc() = getChatAdministrators()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getGameHighScoresSc(userId: Long, messageId: Long) = getGameHighScores(userId,  messageId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setChatPhotoSc(file: ImplicitFile) = setChatPhoto(file)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getChatMemberSc(userId: Long) = getChatMember(userId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setMyDescriptionSc(
+    description: String? = null,
+    languageCode: String? = null,
+) = setMyDescription(
+    description, 
+    languageCode, )
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.sendLocationSc(latitude: Float, longitude: Float) = sendLocation(latitude,  longitude)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.editMessageReplyMarkupSc() = editMessageReplyMarkup()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.voiceSc(file: ImplicitFile) = voice(file)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.uploadStickerFileSc(sticker: InputFile, stickerFormat: StickerFormat) = uploadStickerFile(sticker,  stickerFormat)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.addStickerToSetSc(name: String, input: InputSticker) = addStickerToSet(name,  input)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.deleteMessageSc(messageId: Long) = deleteMessage(messageId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setChatAdministratorCustomTitleSc(userId: Long, customTitle: String) = setChatAdministratorCustomTitle(userId,  customTitle)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.exportChatInviteLinkSc() = exportChatInviteLink()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.banChatMemberSc(userId: Long, untilDate: Instant? = null, revokeMessages: Boolean? = null) = banChatMember(userId,  untilDate,  revokeMessages)
 @Suppress("NOTHING_TO_INLINE")
 inline fun TelegramBot.getWebhookInfoSc() = getWebhookInfo()
-
 @Suppress("NOTHING_TO_INLINE")
-inline fun TelegramBot.deleteWebhookSc(dropPendingUpdates: Boolean = false) = deleteWebhook(dropPendingUpdates)
-
+inline fun TelegramBot.deleteForumTopicSc(messageThreadId: Int) = deleteForumTopic(messageThreadId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getStickerSetSc(name: String) = getStickerSet(name)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.editMessageMediaSc(messageId: Long, inputMedia: InputMedia) = editMessageMedia(messageId,  inputMedia)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.answerPreCheckoutQuerySc(preCheckoutQueryId: String, ok: Boolean = true, errorMessage: String? = null) = answerPreCheckoutQuery(preCheckoutQueryId,  ok,  errorMessage)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.chatActionSc(action: ChatAction, messageThreadId: Int? = null) = chatAction(action,  messageThreadId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.sendGameSc(gameShortName: String) = sendGame(gameShortName)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.createChatInviteLinkSc() = createChatInviteLink()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.createNewStickerSetSc(
+    name: String,
+    title: String,
+    stickers: List<InputSticker>,
+) = createNewStickerSet(
+    name, 
+    title, 
+    stickers, )
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setStickerSetTitleSc(name: String, title: String) = setStickerSetTitle(name,  title)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getMyNameSc(languageCode: String? = null) = getMyName(languageCode)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.stickerSc(file: ImplicitFile) = sticker(file)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.promoteChatMemberSc(userId: Long) = promoteChatMember(userId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.closeForumTopicSc(messageThreadId: Int) = closeForumTopic(messageThreadId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setStickerKeywordsSc(sticker: String, keywords: List<String>? = null) = setStickerKeywords(sticker,  keywords)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setChatTitleSc(title: String) = setChatTitle(title)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.createForumTopicSc(name: String, iconColor: IconColor? = null, iconCustomEmojiId: String? = null) = createForumTopic(name,  iconColor,  iconCustomEmojiId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setStickerEmojiListSc(sticker: String, emojiList: List<String>) = setStickerEmojiList(sticker,  emojiList)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.stopMessageLiveLocationSc(messageId: Long) = stopMessageLiveLocation(messageId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.editMessageTextSc(messageId: Long, block: () -> String) = editMessageText(messageId,  block)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getMeSc() = getMe()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setMessageReactionSc(messageId: Long, reaction: List<ReactionType>? = null, isBig: Boolean? = null) = setMessageReaction(messageId,  reaction,  isBig)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.reopenForumTopicSc(messageThreadId: Int) = reopenForumTopic(messageThreadId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.videoSc(file: ImplicitFile) = video(file)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.pinChatMessageSc(messageId: Long, disableNotification: Boolean? = null) = pinChatMessage(messageId,  disableNotification)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setMyCommandsSc(languageCode: String? = null, scope: BotCommandScope? = null, command: List<BotCommand>) = setMyCommands(languageCode,  scope,  command)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.copyMessageSc(fromChatId: Identifier, messageId: Long) = copyMessage(fromChatId,  messageId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.closeGeneralForumTopicSc() = closeGeneralForumTopic()
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setStickerSetThumbnailSc(name: String, format: StickerFormat, thumbnail: ImplicitFile? = null) = setStickerSetThumbnail(name,  format,  thumbnail)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setChatPermissionsSc(
+    permissions: ChatPermissions,
+    useIndependentChatPermissions: Boolean? = null,
+) = setChatPermissions(
+    permissions, 
+    useIndependentChatPermissions, )
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setStickerMaskPositionSc(sticker: String, maskPosition: MaskPosition? = null) = setStickerMaskPosition(sticker,  maskPosition)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getMyShortDescriptionSc(languageCode: String? = null) = getMyShortDescription(languageCode)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.venueSc(latitude: Float, longitude: Float, title: String, address: String) = venue(latitude,  longitude,  title,  address)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setMyDefaultAdministratorRightsSc(rights: ChatAdministratorRights? = null, forChannel: Boolean? = null) = setMyDefaultAdministratorRights(rights,  forChannel)
 @Suppress("NOTHING_TO_INLINE")
 inline fun TelegramBot.getUserChatBoostsSc(userId: Long) = getUserChatBoosts(userId)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.answerWebAppQuerySc(
+    webAppQueryId: String,
+    result: InlineQueryResult,
+) = answerWebAppQuery(
+    webAppQueryId, 
+    result, )
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.deleteWebhookSc(dropPendingUpdates: Boolean = false) = deleteWebhook(dropPendingUpdates)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.sendDiceSc(emoji: String? = null) = sendDice(emoji)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.deleteMyCommandsSc(languageCode: String? = null, scope: BotCommandScope? = null) = deleteMyCommands(languageCode,  scope)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setGameScoreSc(userId: Long, messageId: Long, score: Long) = setGameScore(userId,  messageId,  score)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.setMyNameSc(name: String? = null, languageCode: String? = null) = setMyName(name,  languageCode)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.getUserProfilePhotosSc(userId: Long, offset: Int? = null, limit: Int? = null) = getUserProfilePhotos(userId,  offset,  limit)
+@Suppress("NOTHING_TO_INLINE")
+inline fun TelegramBot.pollSc(question: String, options: List<String>) = poll(question,  options)

--- a/telegram-bot/api/telegram-bot.api
+++ b/telegram-bot/api/telegram-bot.api
@@ -88,7 +88,7 @@ public final class eu/vendeli/tgbot/api/GetFileKt {
 	public static final fun getFile (Ljava/lang/String;)Leu/vendeli/tgbot/api/GetFileAction;
 }
 
-public final class eu/vendeli/tgbot/api/GetGameHighScoresAction : eu/vendeli/tgbot/interfaces/InlinableAction {
+public final class eu/vendeli/tgbot/api/GetGameHighScoresAction : eu/vendeli/tgbot/interfaces/Action {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/Identifier;)V
 	public fun <init> (Leu/vendeli/tgbot/types/internal/Identifier;J)V
 }
@@ -140,7 +140,7 @@ public final class eu/vendeli/tgbot/api/PollKt {
 	public static final fun sendPoll (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/api/SendPollAction;
 }
 
-public final class eu/vendeli/tgbot/api/SendContactAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/SendContactAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendContactAction;
 	public synthetic fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
@@ -157,9 +157,11 @@ public final class eu/vendeli/tgbot/api/SendContactAction : eu/vendeli/tgbot/int
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendContactAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class eu/vendeli/tgbot/api/SendDiceAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/SendDiceAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -178,9 +180,11 @@ public final class eu/vendeli/tgbot/api/SendDiceAction : eu/vendeli/tgbot/interf
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendDiceAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class eu/vendeli/tgbot/api/SendGameAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/SendGameAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Ljava/lang/String;)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendGameAction;
 	public synthetic fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
@@ -197,6 +201,8 @@ public final class eu/vendeli/tgbot/api/SendGameAction : eu/vendeli/tgbot/interf
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendGameAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/SendInvoiceAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
@@ -218,7 +224,7 @@ public final class eu/vendeli/tgbot/api/SendInvoiceAction : eu/vendeli/tgbot/int
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
 }
 
-public final class eu/vendeli/tgbot/api/SendLocationAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/SendLocationAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (FF)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendLocationAction;
 	public synthetic fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
@@ -235,6 +241,8 @@ public final class eu/vendeli/tgbot/api/SendLocationAction : eu/vendeli/tgbot/in
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendLocationAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/SendPollAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
@@ -275,12 +283,14 @@ public final class eu/vendeli/tgbot/api/SendVenueAction : eu/vendeli/tgbot/inter
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
 }
 
-public final class eu/vendeli/tgbot/api/SetGameScoreAction : eu/vendeli/tgbot/interfaces/InlinableAction, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/SetGameScoreAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/InlineActionExt, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (JJ)V
 	public fun <init> (JJJ)V
 	public synthetic fun getOptions$telegram_bot ()Leu/vendeli/tgbot/types/internal/options/Options;
 	public fun options (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/api/SetGameScoreAction;
 	public synthetic fun options (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/SetGameScoreKt {
@@ -314,7 +324,7 @@ public final class eu/vendeli/tgbot/api/SetPassportDataErrorsKt {
 	public static final fun setPassportDataErrors (JLkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/api/SetPassportDataErrorsAction;
 }
 
-public final class eu/vendeli/tgbot/api/StopMessageLiveLocationAction : eu/vendeli/tgbot/interfaces/InlinableAction, eu/vendeli/tgbot/interfaces/features/MarkupFeature {
+public final class eu/vendeli/tgbot/api/StopMessageLiveLocationAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/InlineActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature {
 	public fun <init> ()V
 	public fun <init> (J)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/StopMessageLiveLocationAction;
@@ -329,6 +339,8 @@ public final class eu/vendeli/tgbot/api/StopMessageLiveLocationAction : eu/vende
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/StopMessageLiveLocationAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/StopMessageLiveLocationKt {
@@ -336,7 +348,7 @@ public final class eu/vendeli/tgbot/api/StopMessageLiveLocationKt {
 	public static final fun stopMessageLiveLocation (J)Leu/vendeli/tgbot/api/StopMessageLiveLocationAction;
 }
 
-public final class eu/vendeli/tgbot/api/StopPollAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/features/MarkupFeature {
+public final class eu/vendeli/tgbot/api/StopPollAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature {
 	public fun <init> (J)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendPollAction;
 	public synthetic fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
@@ -350,6 +362,8 @@ public final class eu/vendeli/tgbot/api/StopPollAction : eu/vendeli/tgbot/interf
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/SendPollAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/StopPollKt {
@@ -457,6 +471,14 @@ public final class eu/vendeli/tgbot/api/botactions/DeleteWebhookAction : eu/vend
 public final class eu/vendeli/tgbot/api/botactions/DeleteWebhookKt {
 	public static final fun deleteWebhook (Z)Leu/vendeli/tgbot/api/botactions/DeleteWebhookAction;
 	public static synthetic fun deleteWebhook$default (ZILjava/lang/Object;)Leu/vendeli/tgbot/api/botactions/DeleteWebhookAction;
+}
+
+public final class eu/vendeli/tgbot/api/botactions/GetBusinessConnectionAction : eu/vendeli/tgbot/interfaces/SimpleAction {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class eu/vendeli/tgbot/api/botactions/GetBusinessConnectionKt {
+	public static final fun getBusinessConnection (Ljava/lang/String;)Leu/vendeli/tgbot/api/botactions/GetBusinessConnectionAction;
 }
 
 public final class eu/vendeli/tgbot/api/botactions/GetMeAction : eu/vendeli/tgbot/interfaces/SimpleAction {
@@ -812,9 +834,11 @@ public final class eu/vendeli/tgbot/api/chat/RevokeChatInviteLinkKt {
 	public static final fun revokeChatInviteLink (Ljava/lang/String;)Leu/vendeli/tgbot/api/chat/RevokeChatInviteLinkAction;
 }
 
-public final class eu/vendeli/tgbot/api/chat/SendChatAction : eu/vendeli/tgbot/interfaces/Action {
+public final class eu/vendeli/tgbot/api/chat/SendChatAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/BusinessActionExt {
 	public fun <init> (Leu/vendeli/tgbot/types/chat/ChatAction;Ljava/lang/Integer;)V
 	public synthetic fun <init> (Leu/vendeli/tgbot/types/chat/ChatAction;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/chat/SetChatAdministratorCustomTitleAction : eu/vendeli/tgbot/interfaces/Action {
@@ -1095,7 +1119,7 @@ public final class eu/vendeli/tgbot/api/media/Photo_jvmKt {
 	public static final fun photo (Ljava/io/File;)Leu/vendeli/tgbot/api/media/SendPhotoAction;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendAnimationAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendAnimationAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun bold (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1135,6 +1159,8 @@ public final class eu/vendeli/tgbot/api/media/SendAnimationAction : eu/vendeli/t
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendAnimationAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1143,7 +1169,7 @@ public final class eu/vendeli/tgbot/api/media/SendAnimationAction : eu/vendeli/t
 	public fun url (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendAudioAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendAudioAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun bold (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1183,6 +1209,8 @@ public final class eu/vendeli/tgbot/api/media/SendAudioAction : eu/vendeli/tgbot
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendAudioAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1191,7 +1219,7 @@ public final class eu/vendeli/tgbot/api/media/SendAudioAction : eu/vendeli/tgbot
 	public fun url (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendDocumentAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendDocumentAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun bold (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1231,6 +1259,8 @@ public final class eu/vendeli/tgbot/api/media/SendDocumentAction : eu/vendeli/tg
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendDocumentAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1239,14 +1269,16 @@ public final class eu/vendeli/tgbot/api/media/SendDocumentAction : eu/vendeli/tg
 	public fun url (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendMediaGroupAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendMediaGroupAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Ljava/util/List;)V
 	public synthetic fun getOptions$telegram_bot ()Leu/vendeli/tgbot/types/internal/options/Options;
 	public fun options (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/api/media/SendMediaGroupAction;
 	public synthetic fun options (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendPhotoAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendPhotoAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun bold (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1286,6 +1318,8 @@ public final class eu/vendeli/tgbot/api/media/SendPhotoAction : eu/vendeli/tgbot
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendPhotoAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1294,7 +1328,7 @@ public final class eu/vendeli/tgbot/api/media/SendPhotoAction : eu/vendeli/tgbot
 	public fun url (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendStickerAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendStickerAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendStickerAction;
 	public synthetic fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
@@ -1311,9 +1345,11 @@ public final class eu/vendeli/tgbot/api/media/SendStickerAction : eu/vendeli/tgb
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendStickerAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendVideoAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendVideoAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun bold (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1353,6 +1389,8 @@ public final class eu/vendeli/tgbot/api/media/SendVideoAction : eu/vendeli/tgbot
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendVideoAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1361,7 +1399,7 @@ public final class eu/vendeli/tgbot/api/media/SendVideoAction : eu/vendeli/tgbot
 	public fun url (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendVideoNoteAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendVideoNoteAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendVideoNoteAction;
 	public synthetic fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
@@ -1378,9 +1416,11 @@ public final class eu/vendeli/tgbot/api/media/SendVideoNoteAction : eu/vendeli/t
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendVideoNoteAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class eu/vendeli/tgbot/api/media/SendVoiceAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/media/SendVoiceAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun bold (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1420,6 +1460,8 @@ public final class eu/vendeli/tgbot/api/media/SendVoiceAction : eu/vendeli/tgbot
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/media/SendVoiceAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1568,7 +1610,7 @@ public final class eu/vendeli/tgbot/api/message/DeleteMessagesKt {
 	public static final fun deleteMessages ([J)Leu/vendeli/tgbot/api/message/DeleteMessagesAction;
 }
 
-public final class eu/vendeli/tgbot/api/message/EditMessageCaptionAction : eu/vendeli/tgbot/interfaces/InlinableAction, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/message/EditMessageCaptionAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/InlineActionExt, eu/vendeli/tgbot/interfaces/features/CaptionFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> ()V
 	public fun <init> (J)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1609,6 +1651,8 @@ public final class eu/vendeli/tgbot/api/message/EditMessageCaptionAction : eu/ve
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/EditMessageCaptionAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1624,7 +1668,7 @@ public final class eu/vendeli/tgbot/api/message/EditMessageCaptionKt {
 	public static final fun editMessageCaption (J)Leu/vendeli/tgbot/api/message/EditMessageCaptionAction;
 }
 
-public final class eu/vendeli/tgbot/api/message/EditMessageLiveLocationAction : eu/vendeli/tgbot/interfaces/InlinableAction, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
+public final class eu/vendeli/tgbot/api/message/EditMessageLiveLocationAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/InlineActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
 	public fun <init> (FF)V
 	public fun <init> (JFF)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/EditMessageLiveLocationAction;
@@ -1642,6 +1686,8 @@ public final class eu/vendeli/tgbot/api/message/EditMessageLiveLocationAction : 
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/EditMessageLiveLocationAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/message/EditMessageLiveLocationKt {
@@ -1649,7 +1695,7 @@ public final class eu/vendeli/tgbot/api/message/EditMessageLiveLocationKt {
 	public static final fun editMessageLiveLocation (JFF)Leu/vendeli/tgbot/api/message/EditMessageLiveLocationAction;
 }
 
-public final class eu/vendeli/tgbot/api/message/EditMessageMediaAction : eu/vendeli/tgbot/interfaces/InlinableAction, eu/vendeli/tgbot/interfaces/features/MarkupFeature {
+public final class eu/vendeli/tgbot/api/message/EditMessageMediaAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/InlineActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature {
 	public fun <init> (JLeu/vendeli/tgbot/types/media/InputMedia;)V
 	public fun <init> (Leu/vendeli/tgbot/types/media/InputMedia;)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/EditMessageMediaAction;
@@ -1664,6 +1710,8 @@ public final class eu/vendeli/tgbot/api/message/EditMessageMediaAction : eu/vend
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/EditMessageMediaAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/message/EditMessageMediaKt {
@@ -1673,7 +1721,7 @@ public final class eu/vendeli/tgbot/api/message/EditMessageMediaKt {
 	public static final fun editMessageMedia (Leu/vendeli/tgbot/types/media/InputMedia;)Leu/vendeli/tgbot/api/message/EditMessageMediaAction;
 }
 
-public final class eu/vendeli/tgbot/api/message/EditMessageReplyMarkupAction : eu/vendeli/tgbot/interfaces/InlinableAction, eu/vendeli/tgbot/interfaces/features/MarkupFeature {
+public final class eu/vendeli/tgbot/api/message/EditMessageReplyMarkupAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/InlineActionExt, eu/vendeli/tgbot/interfaces/features/MarkupFeature {
 	public fun <init> ()V
 	public fun <init> (J)V
 	public fun forceReply (Ljava/lang/String;Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/EditMessageReplyMarkupAction;
@@ -1688,6 +1736,8 @@ public final class eu/vendeli/tgbot/api/message/EditMessageReplyMarkupAction : e
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/EditMessageReplyMarkupAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class eu/vendeli/tgbot/api/message/EditMessageReplyMarkupKt {
@@ -1697,7 +1747,7 @@ public final class eu/vendeli/tgbot/api/message/EditMessageReplyMarkupKt {
 	public static final fun editMessageReplyMarkup (J)Leu/vendeli/tgbot/api/message/EditMessageReplyMarkupAction;
 }
 
-public final class eu/vendeli/tgbot/api/message/EditMessageTextAction : eu/vendeli/tgbot/interfaces/InlinableAction, eu/vendeli/tgbot/interfaces/features/EntitiesFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature, eu/vendeli/tgbot/utils/builders/EntitiesContextBuilder {
+public final class eu/vendeli/tgbot/api/message/EditMessageTextAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/InlineActionExt, eu/vendeli/tgbot/interfaces/features/EntitiesFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature, eu/vendeli/tgbot/utils/builders/EntitiesContextBuilder {
 	public fun <init> (JLjava/lang/String;)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1736,6 +1786,8 @@ public final class eu/vendeli/tgbot/api/message/EditMessageTextAction : eu/vende
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/EditMessageTextAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1788,7 +1840,7 @@ public final class eu/vendeli/tgbot/api/message/MessageKt {
 	public static final fun sendMessage (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/api/message/SendMessageAction;
 }
 
-public final class eu/vendeli/tgbot/api/message/SendMessageAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/features/EntitiesFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature, eu/vendeli/tgbot/utils/builders/EntitiesContextBuilder {
+public final class eu/vendeli/tgbot/api/message/SendMessageAction : eu/vendeli/tgbot/interfaces/Action, eu/vendeli/tgbot/interfaces/BusinessActionExt, eu/vendeli/tgbot/interfaces/features/EntitiesFeature, eu/vendeli/tgbot/interfaces/features/MarkupFeature, eu/vendeli/tgbot/interfaces/features/OptionsFeature, eu/vendeli/tgbot/utils/builders/EntitiesContextBuilder {
 	public fun <init> (Ljava/lang/String;)V
 	public fun blockquote (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun bold (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
@@ -1826,6 +1878,8 @@ public final class eu/vendeli/tgbot/api/message/SendMessageAction : eu/vendeli/t
 	public synthetic fun replyKeyboardMarkup (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 	public fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/api/message/SendMessageAction;
 	public synthetic fun replyKeyboardRemove (Ljava/lang/Boolean;)Leu/vendeli/tgbot/interfaces/TgAction;
+	public fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun spoiler (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun strikethrough (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
 	public fun textLink (Leu/vendeli/tgbot/utils/builders/EntitiesContextBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lkotlin/Triple;
@@ -1844,14 +1898,14 @@ public final class eu/vendeli/tgbot/api/stickerset/AddStickerToSetKt {
 }
 
 public final class eu/vendeli/tgbot/api/stickerset/CreateNewStickerSetAction : eu/vendeli/tgbot/interfaces/MediaAction, eu/vendeli/tgbot/interfaces/features/OptionsFeature {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerFormat;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
 	public synthetic fun getOptions$telegram_bot ()Leu/vendeli/tgbot/types/internal/options/Options;
 	public fun options (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/api/stickerset/CreateNewStickerSetAction;
 	public synthetic fun options (Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
 }
 
 public final class eu/vendeli/tgbot/api/stickerset/CreateNewStickerSetKt {
-	public static final fun createNewStickerSet (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerFormat;Ljava/util/List;)Leu/vendeli/tgbot/api/stickerset/CreateNewStickerSetAction;
+	public static final fun createNewStickerSet (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Leu/vendeli/tgbot/api/stickerset/CreateNewStickerSetAction;
 }
 
 public final class eu/vendeli/tgbot/api/stickerset/DeleteStickerFromSetAction : eu/vendeli/tgbot/interfaces/SimpleAction {
@@ -1885,6 +1939,14 @@ public final class eu/vendeli/tgbot/api/stickerset/GetStickerSetAction : eu/vend
 
 public final class eu/vendeli/tgbot/api/stickerset/GetStickerSetKt {
 	public static final fun getStickerSet (Ljava/lang/String;)Leu/vendeli/tgbot/api/stickerset/GetStickerSetAction;
+}
+
+public final class eu/vendeli/tgbot/api/stickerset/ReplaceStickerInSetAction : eu/vendeli/tgbot/interfaces/Action {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/InputSticker;)V
+}
+
+public final class eu/vendeli/tgbot/api/stickerset/ReplaceStickerInSetKt {
+	public static final fun replaceStickerInSet (Ljava/lang/String;)Leu/vendeli/tgbot/api/stickerset/DeleteStickerSetAction;
 }
 
 public final class eu/vendeli/tgbot/api/stickerset/SetCustomEmojiStickerSetThumbnailAction : eu/vendeli/tgbot/interfaces/SimpleAction {
@@ -1934,13 +1996,13 @@ public final class eu/vendeli/tgbot/api/stickerset/SetStickerPositionInSetKt {
 }
 
 public final class eu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnailAction : eu/vendeli/tgbot/interfaces/MediaAction {
-	public fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
-	public synthetic fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/internal/ImplicitFile;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerFormat;Leu/vendeli/tgbot/types/internal/ImplicitFile;)V
+	public synthetic fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerFormat;Leu/vendeli/tgbot/types/internal/ImplicitFile;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class eu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnailKt {
-	public static final fun setStickerSetThumbnail (Ljava/lang/String;Leu/vendeli/tgbot/types/internal/ImplicitFile;)Leu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnailAction;
-	public static synthetic fun setStickerSetThumbnail$default (Ljava/lang/String;Leu/vendeli/tgbot/types/internal/ImplicitFile;ILjava/lang/Object;)Leu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnailAction;
+	public static final fun setStickerSetThumbnail (Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerFormat;Leu/vendeli/tgbot/types/internal/ImplicitFile;)Leu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnailAction;
+	public static synthetic fun setStickerSetThumbnail$default (Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerFormat;Leu/vendeli/tgbot/types/internal/ImplicitFile;ILjava/lang/Object;)Leu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnailAction;
 }
 
 public final class eu/vendeli/tgbot/api/stickerset/SetStickerSetTitleAction : eu/vendeli/tgbot/interfaces/SimpleAction {
@@ -1970,6 +2032,8 @@ public final class eu/vendeli/tgbot/core/FunctionalHandlingDsl {
 	public static synthetic fun breakIf$default (Leu/vendeli/tgbot/core/FunctionalHandlingDsl;Leu/vendeli/tgbot/types/internal/SingleInputChain;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Leu/vendeli/tgbot/types/internal/SingleInputChain;
 	public final fun inputChain (Ljava/lang/String;Leu/vendeli/tgbot/types/internal/configuration/RateLimits;Lkotlin/jvm/functions/Function2;)Leu/vendeli/tgbot/types/internal/SingleInputChain;
 	public static synthetic fun inputChain$default (Leu/vendeli/tgbot/core/FunctionalHandlingDsl;Ljava/lang/String;Leu/vendeli/tgbot/types/internal/configuration/RateLimits;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Leu/vendeli/tgbot/types/internal/SingleInputChain;
+	public final fun onBusinessConnection (Lkotlin/jvm/functions/Function2;)V
+	public final fun onBusinessMessage (Lkotlin/jvm/functions/Function2;)V
 	public final fun onCallbackQuery (Lkotlin/jvm/functions/Function2;)V
 	public final fun onChannelPost (Lkotlin/jvm/functions/Function2;)V
 	public final fun onChatBoost (Lkotlin/jvm/functions/Function2;)V
@@ -1980,6 +2044,8 @@ public final class eu/vendeli/tgbot/core/FunctionalHandlingDsl {
 	public final fun onCommand (Lkotlin/text/Regex;Ljava/util/Set;Leu/vendeli/tgbot/types/internal/configuration/RateLimits;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun onCommand$default (Leu/vendeli/tgbot/core/FunctionalHandlingDsl;Ljava/lang/String;Ljava/util/Set;Leu/vendeli/tgbot/types/internal/configuration/RateLimits;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static synthetic fun onCommand$default (Leu/vendeli/tgbot/core/FunctionalHandlingDsl;Lkotlin/text/Regex;Ljava/util/Set;Leu/vendeli/tgbot/types/internal/configuration/RateLimits;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public final fun onDeletedBusinessMessages (Lkotlin/jvm/functions/Function2;)V
+	public final fun onEditedBusinessMessage (Lkotlin/jvm/functions/Function2;)V
 	public final fun onEditedChannelPost (Lkotlin/jvm/functions/Function2;)V
 	public final fun onEditedMessage (Lkotlin/jvm/functions/Function2;)V
 	public final fun onInlineQuery (Lkotlin/jvm/functions/Function2;)V
@@ -2103,6 +2169,19 @@ public final class eu/vendeli/tgbot/interfaces/BotContext$DefaultImpls {
 	public static fun setAsync (Leu/vendeli/tgbot/interfaces/BotContext;Leu/vendeli/tgbot/types/User;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class eu/vendeli/tgbot/interfaces/BusinessActionExt : eu/vendeli/tgbot/interfaces/Request {
+	public abstract fun sendBusiness (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun sendBusinessAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class eu/vendeli/tgbot/interfaces/BusinessActionExt$DefaultImpls {
+	public static fun doRequest (Leu/vendeli/tgbot/interfaces/BusinessActionExt;Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun doRequestAsync (Leu/vendeli/tgbot/interfaces/BusinessActionExt;Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getParameters (Leu/vendeli/tgbot/interfaces/BusinessActionExt;Leu/vendeli/tgbot/interfaces/Request;)Ljava/util/Map;
+	public static fun sendBusiness (Leu/vendeli/tgbot/interfaces/BusinessActionExt;Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun sendBusinessAsync (Leu/vendeli/tgbot/interfaces/BusinessActionExt;Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class eu/vendeli/tgbot/interfaces/Button {
 }
 
@@ -2133,10 +2212,17 @@ public final class eu/vendeli/tgbot/interfaces/ConfigLoader$DefaultImpls {
 	public static fun getCommandsPackage (Leu/vendeli/tgbot/interfaces/ConfigLoader;)Ljava/lang/String;
 }
 
-public abstract class eu/vendeli/tgbot/interfaces/InlinableAction : eu/vendeli/tgbot/interfaces/Action {
-	public fun <init> ()V
-	public final fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+public abstract interface class eu/vendeli/tgbot/interfaces/InlineActionExt : eu/vendeli/tgbot/interfaces/Request {
+	public abstract fun sendInline (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun sendInlineAsync (Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class eu/vendeli/tgbot/interfaces/InlineActionExt$DefaultImpls {
+	public static fun doRequest (Leu/vendeli/tgbot/interfaces/InlineActionExt;Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun doRequestAsync (Leu/vendeli/tgbot/interfaces/InlineActionExt;Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getParameters (Leu/vendeli/tgbot/interfaces/InlineActionExt;Leu/vendeli/tgbot/interfaces/Request;)Ljava/util/Map;
+	public static fun sendInline (Leu/vendeli/tgbot/interfaces/InlineActionExt;Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun sendInlineAsync (Leu/vendeli/tgbot/interfaces/InlineActionExt;Ljava/lang/String;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class eu/vendeli/tgbot/interfaces/InputListener {
@@ -2193,14 +2279,29 @@ public abstract interface class eu/vendeli/tgbot/interfaces/RateLimitMechanism {
 	public abstract fun isLimited (Leu/vendeli/tgbot/types/internal/configuration/RateLimits;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class eu/vendeli/tgbot/interfaces/Request {
+	public abstract fun doRequest (Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun doRequestAsync (Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getParameters (Leu/vendeli/tgbot/interfaces/Request;)Ljava/util/Map;
+}
+
+public final class eu/vendeli/tgbot/interfaces/Request$DefaultImpls {
+	public static fun doRequest (Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun doRequestAsync (Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getParameters (Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/interfaces/Request;)Ljava/util/Map;
+}
+
 public abstract class eu/vendeli/tgbot/interfaces/SimpleAction : eu/vendeli/tgbot/interfaces/TgAction {
 	public fun <init> ()V
 	public fun send (Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun sendAsync (Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract class eu/vendeli/tgbot/interfaces/TgAction {
+public abstract class eu/vendeli/tgbot/interfaces/TgAction : eu/vendeli/tgbot/interfaces/Request {
 	public fun <init> ()V
+	public fun doRequest (Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun doRequestAsync (Leu/vendeli/tgbot/interfaces/Request;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getParameters (Leu/vendeli/tgbot/interfaces/Request;)Ljava/util/Map;
 }
 
 public abstract interface class eu/vendeli/tgbot/interfaces/UserData : eu/vendeli/tgbot/interfaces/BotContext {
@@ -2288,6 +2389,38 @@ public abstract interface class eu/vendeli/tgbot/interfaces/features/OptionsFeat
 
 public final class eu/vendeli/tgbot/interfaces/features/OptionsFeature$DefaultImpls {
 	public static fun options (Leu/vendeli/tgbot/interfaces/features/OptionsFeature;Lkotlin/jvm/functions/Function1;)Leu/vendeli/tgbot/interfaces/TgAction;
+}
+
+public final class eu/vendeli/tgbot/types/Birthdate {
+	public static final field Companion Leu/vendeli/tgbot/types/Birthdate$Companion;
+	public fun <init> (IILjava/lang/Integer;)V
+	public synthetic fun <init> (IILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (IILjava/lang/Integer;)Leu/vendeli/tgbot/types/Birthdate;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/Birthdate;IILjava/lang/Integer;ILjava/lang/Object;)Leu/vendeli/tgbot/types/Birthdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDay ()I
+	public final fun getMonth ()I
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/Birthdate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Leu/vendeli/tgbot/types/Birthdate$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/Birthdate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/Birthdate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/Birthdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class eu/vendeli/tgbot/types/CallbackQuery {
@@ -2951,92 +3084,96 @@ public final class eu/vendeli/tgbot/types/MaybeInaccessibleMessage$InaccessibleM
 
 public final class eu/vendeli/tgbot/types/Message : eu/vendeli/tgbot/types/MaybeInaccessibleMessage, eu/vendeli/tgbot/interfaces/MultipleResponse {
 	public static final field Companion Leu/vendeli/tgbot/types/Message$Companion;
-	public fun <init> (JLjava/lang/Integer;Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/chat/Chat;Ljava/lang/Integer;Lkotlinx/datetime/Instant;Leu/vendeli/tgbot/types/chat/Chat;Leu/vendeli/tgbot/types/MessageOrigin;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/ExternalReplyInfo;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/TextQuote;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;Leu/vendeli/tgbot/types/media/Animation;Leu/vendeli/tgbot/types/media/Audio;Leu/vendeli/tgbot/types/media/Document;Ljava/util/List;Leu/vendeli/tgbot/types/media/Sticker;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/media/Video;Leu/vendeli/tgbot/types/media/VideoNote;Leu/vendeli/tgbot/types/media/Voice;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/Contact;Leu/vendeli/tgbot/types/game/Dice;Leu/vendeli/tgbot/types/game/Game;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/Venue;Leu/vendeli/tgbot/types/Location;Ljava/util/List;Leu/vendeli/tgbot/types/User;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;Ljava/lang/Long;Ljava/lang/Long;Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;Leu/vendeli/tgbot/types/payment/Invoice;Leu/vendeli/tgbot/types/payment/SuccessfulPayment;Leu/vendeli/tgbot/types/UsersShared;Leu/vendeli/tgbot/types/chat/ChatShared;Ljava/lang/String;Leu/vendeli/tgbot/types/WriteAccessAllowed;Leu/vendeli/tgbot/types/passport/PassportData;Leu/vendeli/tgbot/types/ProximityAlertTriggered;Leu/vendeli/tgbot/types/boost/ChatBoostAdded;Leu/vendeli/tgbot/types/forum/ForumTopicCreated;Leu/vendeli/tgbot/types/forum/ForumTopicEdited;Leu/vendeli/tgbot/types/forum/ForumTopicClosed;Leu/vendeli/tgbot/types/forum/ForumTopicReopened;Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;Leu/vendeli/tgbot/types/GiveawayCreated;Leu/vendeli/tgbot/types/Giveaway;Leu/vendeli/tgbot/types/GiveawayWinners;Leu/vendeli/tgbot/types/GiveawayCompleted;Leu/vendeli/tgbot/types/media/VideoChatScheduled;Leu/vendeli/tgbot/types/media/VideoChatStarted;Leu/vendeli/tgbot/types/media/VideoChatEnded;Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;Leu/vendeli/tgbot/types/keyboard/WebAppData;Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (JLjava/lang/Integer;Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/chat/Chat;Ljava/lang/Integer;Lkotlinx/datetime/Instant;Leu/vendeli/tgbot/types/chat/Chat;Leu/vendeli/tgbot/types/MessageOrigin;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/ExternalReplyInfo;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/TextQuote;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;Leu/vendeli/tgbot/types/media/Animation;Leu/vendeli/tgbot/types/media/Audio;Leu/vendeli/tgbot/types/media/Document;Ljava/util/List;Leu/vendeli/tgbot/types/media/Sticker;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/media/Video;Leu/vendeli/tgbot/types/media/VideoNote;Leu/vendeli/tgbot/types/media/Voice;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/Contact;Leu/vendeli/tgbot/types/game/Dice;Leu/vendeli/tgbot/types/game/Game;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/Venue;Leu/vendeli/tgbot/types/Location;Ljava/util/List;Leu/vendeli/tgbot/types/User;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;Ljava/lang/Long;Ljava/lang/Long;Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;Leu/vendeli/tgbot/types/payment/Invoice;Leu/vendeli/tgbot/types/payment/SuccessfulPayment;Leu/vendeli/tgbot/types/UsersShared;Leu/vendeli/tgbot/types/chat/ChatShared;Ljava/lang/String;Leu/vendeli/tgbot/types/WriteAccessAllowed;Leu/vendeli/tgbot/types/passport/PassportData;Leu/vendeli/tgbot/types/ProximityAlertTriggered;Leu/vendeli/tgbot/types/boost/ChatBoostAdded;Leu/vendeli/tgbot/types/forum/ForumTopicCreated;Leu/vendeli/tgbot/types/forum/ForumTopicEdited;Leu/vendeli/tgbot/types/forum/ForumTopicClosed;Leu/vendeli/tgbot/types/forum/ForumTopicReopened;Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;Leu/vendeli/tgbot/types/GiveawayCreated;Leu/vendeli/tgbot/types/Giveaway;Leu/vendeli/tgbot/types/GiveawayWinners;Leu/vendeli/tgbot/types/GiveawayCompleted;Leu/vendeli/tgbot/types/media/VideoChatScheduled;Leu/vendeli/tgbot/types/media/VideoChatStarted;Leu/vendeli/tgbot/types/media/VideoChatEnded;Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;Leu/vendeli/tgbot/types/keyboard/WebAppData;Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;Ljava/lang/Boolean;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JLjava/lang/Integer;Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/chat/Chat;Ljava/lang/Integer;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/String;Leu/vendeli/tgbot/types/chat/Chat;Leu/vendeli/tgbot/types/MessageOrigin;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/ExternalReplyInfo;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/TextQuote;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;Leu/vendeli/tgbot/types/media/Animation;Leu/vendeli/tgbot/types/media/Audio;Leu/vendeli/tgbot/types/media/Document;Ljava/util/List;Leu/vendeli/tgbot/types/media/Sticker;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/media/Video;Leu/vendeli/tgbot/types/media/VideoNote;Leu/vendeli/tgbot/types/media/Voice;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/Contact;Leu/vendeli/tgbot/types/game/Dice;Leu/vendeli/tgbot/types/game/Game;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/Venue;Leu/vendeli/tgbot/types/Location;Ljava/util/List;Leu/vendeli/tgbot/types/User;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;Ljava/lang/Long;Ljava/lang/Long;Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;Leu/vendeli/tgbot/types/payment/Invoice;Leu/vendeli/tgbot/types/payment/SuccessfulPayment;Leu/vendeli/tgbot/types/UsersShared;Leu/vendeli/tgbot/types/chat/ChatShared;Ljava/lang/String;Leu/vendeli/tgbot/types/WriteAccessAllowed;Leu/vendeli/tgbot/types/passport/PassportData;Leu/vendeli/tgbot/types/ProximityAlertTriggered;Leu/vendeli/tgbot/types/boost/ChatBoostAdded;Leu/vendeli/tgbot/types/forum/ForumTopicCreated;Leu/vendeli/tgbot/types/forum/ForumTopicEdited;Leu/vendeli/tgbot/types/forum/ForumTopicClosed;Leu/vendeli/tgbot/types/forum/ForumTopicReopened;Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;Leu/vendeli/tgbot/types/GiveawayCreated;Leu/vendeli/tgbot/types/Giveaway;Leu/vendeli/tgbot/types/GiveawayWinners;Leu/vendeli/tgbot/types/GiveawayCompleted;Leu/vendeli/tgbot/types/media/VideoChatScheduled;Leu/vendeli/tgbot/types/media/VideoChatStarted;Leu/vendeli/tgbot/types/media/VideoChatEnded;Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;Leu/vendeli/tgbot/types/keyboard/WebAppData;Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (JLjava/lang/Integer;Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/chat/Chat;Ljava/lang/Integer;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/String;Leu/vendeli/tgbot/types/chat/Chat;Leu/vendeli/tgbot/types/MessageOrigin;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/ExternalReplyInfo;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/TextQuote;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;Leu/vendeli/tgbot/types/media/Animation;Leu/vendeli/tgbot/types/media/Audio;Leu/vendeli/tgbot/types/media/Document;Ljava/util/List;Leu/vendeli/tgbot/types/media/Sticker;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/media/Video;Leu/vendeli/tgbot/types/media/VideoNote;Leu/vendeli/tgbot/types/media/Voice;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/Contact;Leu/vendeli/tgbot/types/game/Dice;Leu/vendeli/tgbot/types/game/Game;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/Venue;Leu/vendeli/tgbot/types/Location;Ljava/util/List;Leu/vendeli/tgbot/types/User;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;Ljava/lang/Long;Ljava/lang/Long;Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;Leu/vendeli/tgbot/types/payment/Invoice;Leu/vendeli/tgbot/types/payment/SuccessfulPayment;Leu/vendeli/tgbot/types/UsersShared;Leu/vendeli/tgbot/types/chat/ChatShared;Ljava/lang/String;Leu/vendeli/tgbot/types/WriteAccessAllowed;Leu/vendeli/tgbot/types/passport/PassportData;Leu/vendeli/tgbot/types/ProximityAlertTriggered;Leu/vendeli/tgbot/types/boost/ChatBoostAdded;Leu/vendeli/tgbot/types/forum/ForumTopicCreated;Leu/vendeli/tgbot/types/forum/ForumTopicEdited;Leu/vendeli/tgbot/types/forum/ForumTopicClosed;Leu/vendeli/tgbot/types/forum/ForumTopicReopened;Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;Leu/vendeli/tgbot/types/GiveawayCreated;Leu/vendeli/tgbot/types/Giveaway;Leu/vendeli/tgbot/types/GiveawayWinners;Leu/vendeli/tgbot/types/GiveawayCompleted;Leu/vendeli/tgbot/types/media/VideoChatScheduled;Leu/vendeli/tgbot/types/media/VideoChatStarted;Leu/vendeli/tgbot/types/media/VideoChatEnded;Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;Leu/vendeli/tgbot/types/keyboard/WebAppData;Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;Ljava/lang/Boolean;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
-	public final fun component10 ()Ljava/lang/Boolean;
-	public final fun component11 ()Leu/vendeli/tgbot/types/Message;
-	public final fun component12 ()Leu/vendeli/tgbot/types/ExternalReplyInfo;
-	public final fun component13 ()Leu/vendeli/tgbot/types/media/Story;
-	public final fun component14 ()Leu/vendeli/tgbot/types/TextQuote;
-	public final fun component15 ()Leu/vendeli/tgbot/types/User;
-	public final fun component16 ()Lkotlinx/datetime/Instant;
-	public final fun component17 ()Ljava/lang/Boolean;
-	public final fun component18 ()Ljava/lang/String;
-	public final fun component19 ()Ljava/lang/String;
+	public final fun component10 ()Leu/vendeli/tgbot/types/MessageOrigin;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Leu/vendeli/tgbot/types/Message;
+	public final fun component14 ()Leu/vendeli/tgbot/types/ExternalReplyInfo;
+	public final fun component15 ()Leu/vendeli/tgbot/types/media/Story;
+	public final fun component16 ()Leu/vendeli/tgbot/types/TextQuote;
+	public final fun component17 ()Leu/vendeli/tgbot/types/User;
+	public final fun component18 ()Lkotlinx/datetime/Instant;
+	public final fun component19 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun component20 ()Ljava/lang/String;
-	public final fun component21 ()Ljava/util/List;
-	public final fun component22 ()Leu/vendeli/tgbot/types/LinkPreviewOptions;
-	public final fun component23 ()Leu/vendeli/tgbot/types/media/Animation;
-	public final fun component24 ()Leu/vendeli/tgbot/types/media/Audio;
-	public final fun component25 ()Leu/vendeli/tgbot/types/media/Document;
-	public final fun component26 ()Ljava/util/List;
-	public final fun component27 ()Leu/vendeli/tgbot/types/media/Sticker;
-	public final fun component28 ()Leu/vendeli/tgbot/types/media/Story;
-	public final fun component29 ()Leu/vendeli/tgbot/types/media/Video;
+	public final fun component20 ()Ljava/lang/Boolean;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Ljava/lang/String;
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Leu/vendeli/tgbot/types/LinkPreviewOptions;
+	public final fun component26 ()Leu/vendeli/tgbot/types/media/Animation;
+	public final fun component27 ()Leu/vendeli/tgbot/types/media/Audio;
+	public final fun component28 ()Leu/vendeli/tgbot/types/media/Document;
+	public final fun component29 ()Ljava/util/List;
 	public final fun component3 ()Leu/vendeli/tgbot/types/User;
-	public final fun component30 ()Leu/vendeli/tgbot/types/media/VideoNote;
-	public final fun component31 ()Leu/vendeli/tgbot/types/media/Voice;
-	public final fun component32 ()Ljava/lang/String;
-	public final fun component33 ()Ljava/util/List;
-	public final fun component34 ()Leu/vendeli/tgbot/types/Contact;
-	public final fun component35 ()Leu/vendeli/tgbot/types/game/Dice;
-	public final fun component36 ()Leu/vendeli/tgbot/types/game/Game;
-	public final fun component37 ()Leu/vendeli/tgbot/types/Poll;
-	public final fun component38 ()Leu/vendeli/tgbot/types/Venue;
-	public final fun component39 ()Leu/vendeli/tgbot/types/Location;
+	public final fun component30 ()Leu/vendeli/tgbot/types/media/Sticker;
+	public final fun component31 ()Leu/vendeli/tgbot/types/media/Story;
+	public final fun component32 ()Leu/vendeli/tgbot/types/media/Video;
+	public final fun component33 ()Leu/vendeli/tgbot/types/media/VideoNote;
+	public final fun component34 ()Leu/vendeli/tgbot/types/media/Voice;
+	public final fun component35 ()Ljava/lang/String;
+	public final fun component36 ()Ljava/util/List;
+	public final fun component37 ()Leu/vendeli/tgbot/types/Contact;
+	public final fun component38 ()Leu/vendeli/tgbot/types/game/Dice;
+	public final fun component39 ()Leu/vendeli/tgbot/types/game/Game;
 	public final fun component4 ()Leu/vendeli/tgbot/types/chat/Chat;
-	public final fun component40 ()Ljava/util/List;
-	public final fun component41 ()Leu/vendeli/tgbot/types/User;
-	public final fun component42 ()Ljava/lang/String;
+	public final fun component40 ()Leu/vendeli/tgbot/types/Poll;
+	public final fun component41 ()Leu/vendeli/tgbot/types/Venue;
+	public final fun component42 ()Leu/vendeli/tgbot/types/Location;
 	public final fun component43 ()Ljava/util/List;
-	public final fun component44 ()Ljava/lang/Boolean;
-	public final fun component45 ()Ljava/lang/Boolean;
-	public final fun component46 ()Ljava/lang/Boolean;
+	public final fun component44 ()Leu/vendeli/tgbot/types/User;
+	public final fun component45 ()Ljava/lang/String;
+	public final fun component46 ()Ljava/util/List;
 	public final fun component47 ()Ljava/lang/Boolean;
-	public final fun component48 ()Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;
-	public final fun component49 ()Ljava/lang/Long;
+	public final fun component48 ()Ljava/lang/Boolean;
+	public final fun component49 ()Ljava/lang/Boolean;
 	public final fun component5 ()Ljava/lang/Integer;
-	public final fun component50 ()Ljava/lang/Long;
-	public final fun component51 ()Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;
-	public final fun component52 ()Leu/vendeli/tgbot/types/payment/Invoice;
-	public final fun component53 ()Leu/vendeli/tgbot/types/payment/SuccessfulPayment;
-	public final fun component54 ()Leu/vendeli/tgbot/types/UsersShared;
-	public final fun component55 ()Leu/vendeli/tgbot/types/chat/ChatShared;
-	public final fun component56 ()Ljava/lang/String;
-	public final fun component57 ()Leu/vendeli/tgbot/types/WriteAccessAllowed;
-	public final fun component58 ()Leu/vendeli/tgbot/types/passport/PassportData;
-	public final fun component59 ()Leu/vendeli/tgbot/types/ProximityAlertTriggered;
-	public final fun component6 ()Lkotlinx/datetime/Instant;
-	public final fun component60 ()Leu/vendeli/tgbot/types/boost/ChatBoostAdded;
-	public final fun component61 ()Leu/vendeli/tgbot/types/forum/ForumTopicCreated;
-	public final fun component62 ()Leu/vendeli/tgbot/types/forum/ForumTopicEdited;
-	public final fun component63 ()Leu/vendeli/tgbot/types/forum/ForumTopicClosed;
-	public final fun component64 ()Leu/vendeli/tgbot/types/forum/ForumTopicReopened;
-	public final fun component65 ()Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;
-	public final fun component66 ()Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;
-	public final fun component67 ()Leu/vendeli/tgbot/types/GiveawayCreated;
-	public final fun component68 ()Leu/vendeli/tgbot/types/Giveaway;
-	public final fun component69 ()Leu/vendeli/tgbot/types/GiveawayWinners;
-	public final fun component7 ()Leu/vendeli/tgbot/types/chat/Chat;
-	public final fun component70 ()Leu/vendeli/tgbot/types/GiveawayCompleted;
-	public final fun component71 ()Leu/vendeli/tgbot/types/media/VideoChatScheduled;
-	public final fun component72 ()Leu/vendeli/tgbot/types/media/VideoChatStarted;
-	public final fun component73 ()Leu/vendeli/tgbot/types/media/VideoChatEnded;
-	public final fun component74 ()Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;
-	public final fun component75 ()Leu/vendeli/tgbot/types/keyboard/WebAppData;
-	public final fun component76 ()Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;
-	public final fun component77 ()Ljava/lang/Boolean;
-	public final fun component8 ()Leu/vendeli/tgbot/types/MessageOrigin;
-	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (JLjava/lang/Integer;Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/chat/Chat;Ljava/lang/Integer;Lkotlinx/datetime/Instant;Leu/vendeli/tgbot/types/chat/Chat;Leu/vendeli/tgbot/types/MessageOrigin;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/ExternalReplyInfo;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/TextQuote;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;Leu/vendeli/tgbot/types/media/Animation;Leu/vendeli/tgbot/types/media/Audio;Leu/vendeli/tgbot/types/media/Document;Ljava/util/List;Leu/vendeli/tgbot/types/media/Sticker;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/media/Video;Leu/vendeli/tgbot/types/media/VideoNote;Leu/vendeli/tgbot/types/media/Voice;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/Contact;Leu/vendeli/tgbot/types/game/Dice;Leu/vendeli/tgbot/types/game/Game;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/Venue;Leu/vendeli/tgbot/types/Location;Ljava/util/List;Leu/vendeli/tgbot/types/User;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;Ljava/lang/Long;Ljava/lang/Long;Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;Leu/vendeli/tgbot/types/payment/Invoice;Leu/vendeli/tgbot/types/payment/SuccessfulPayment;Leu/vendeli/tgbot/types/UsersShared;Leu/vendeli/tgbot/types/chat/ChatShared;Ljava/lang/String;Leu/vendeli/tgbot/types/WriteAccessAllowed;Leu/vendeli/tgbot/types/passport/PassportData;Leu/vendeli/tgbot/types/ProximityAlertTriggered;Leu/vendeli/tgbot/types/boost/ChatBoostAdded;Leu/vendeli/tgbot/types/forum/ForumTopicCreated;Leu/vendeli/tgbot/types/forum/ForumTopicEdited;Leu/vendeli/tgbot/types/forum/ForumTopicClosed;Leu/vendeli/tgbot/types/forum/ForumTopicReopened;Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;Leu/vendeli/tgbot/types/GiveawayCreated;Leu/vendeli/tgbot/types/Giveaway;Leu/vendeli/tgbot/types/GiveawayWinners;Leu/vendeli/tgbot/types/GiveawayCompleted;Leu/vendeli/tgbot/types/media/VideoChatScheduled;Leu/vendeli/tgbot/types/media/VideoChatStarted;Leu/vendeli/tgbot/types/media/VideoChatEnded;Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;Leu/vendeli/tgbot/types/keyboard/WebAppData;Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/Message;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/Message;JLjava/lang/Integer;Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/chat/Chat;Ljava/lang/Integer;Lkotlinx/datetime/Instant;Leu/vendeli/tgbot/types/chat/Chat;Leu/vendeli/tgbot/types/MessageOrigin;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/ExternalReplyInfo;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/TextQuote;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;Leu/vendeli/tgbot/types/media/Animation;Leu/vendeli/tgbot/types/media/Audio;Leu/vendeli/tgbot/types/media/Document;Ljava/util/List;Leu/vendeli/tgbot/types/media/Sticker;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/media/Video;Leu/vendeli/tgbot/types/media/VideoNote;Leu/vendeli/tgbot/types/media/Voice;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/Contact;Leu/vendeli/tgbot/types/game/Dice;Leu/vendeli/tgbot/types/game/Game;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/Venue;Leu/vendeli/tgbot/types/Location;Ljava/util/List;Leu/vendeli/tgbot/types/User;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;Ljava/lang/Long;Ljava/lang/Long;Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;Leu/vendeli/tgbot/types/payment/Invoice;Leu/vendeli/tgbot/types/payment/SuccessfulPayment;Leu/vendeli/tgbot/types/UsersShared;Leu/vendeli/tgbot/types/chat/ChatShared;Ljava/lang/String;Leu/vendeli/tgbot/types/WriteAccessAllowed;Leu/vendeli/tgbot/types/passport/PassportData;Leu/vendeli/tgbot/types/ProximityAlertTriggered;Leu/vendeli/tgbot/types/boost/ChatBoostAdded;Leu/vendeli/tgbot/types/forum/ForumTopicCreated;Leu/vendeli/tgbot/types/forum/ForumTopicEdited;Leu/vendeli/tgbot/types/forum/ForumTopicClosed;Leu/vendeli/tgbot/types/forum/ForumTopicReopened;Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;Leu/vendeli/tgbot/types/GiveawayCreated;Leu/vendeli/tgbot/types/Giveaway;Leu/vendeli/tgbot/types/GiveawayWinners;Leu/vendeli/tgbot/types/GiveawayCompleted;Leu/vendeli/tgbot/types/media/VideoChatScheduled;Leu/vendeli/tgbot/types/media/VideoChatStarted;Leu/vendeli/tgbot/types/media/VideoChatEnded;Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;Leu/vendeli/tgbot/types/keyboard/WebAppData;Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;Ljava/lang/Boolean;IIILjava/lang/Object;)Leu/vendeli/tgbot/types/Message;
+	public final fun component50 ()Ljava/lang/Boolean;
+	public final fun component51 ()Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;
+	public final fun component52 ()Ljava/lang/Long;
+	public final fun component53 ()Ljava/lang/Long;
+	public final fun component54 ()Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;
+	public final fun component55 ()Leu/vendeli/tgbot/types/payment/Invoice;
+	public final fun component56 ()Leu/vendeli/tgbot/types/payment/SuccessfulPayment;
+	public final fun component57 ()Leu/vendeli/tgbot/types/UsersShared;
+	public final fun component58 ()Leu/vendeli/tgbot/types/chat/ChatShared;
+	public final fun component59 ()Ljava/lang/String;
+	public final fun component6 ()Leu/vendeli/tgbot/types/User;
+	public final fun component60 ()Leu/vendeli/tgbot/types/WriteAccessAllowed;
+	public final fun component61 ()Leu/vendeli/tgbot/types/passport/PassportData;
+	public final fun component62 ()Leu/vendeli/tgbot/types/ProximityAlertTriggered;
+	public final fun component63 ()Leu/vendeli/tgbot/types/boost/ChatBoostAdded;
+	public final fun component64 ()Leu/vendeli/tgbot/types/forum/ForumTopicCreated;
+	public final fun component65 ()Leu/vendeli/tgbot/types/forum/ForumTopicEdited;
+	public final fun component66 ()Leu/vendeli/tgbot/types/forum/ForumTopicClosed;
+	public final fun component67 ()Leu/vendeli/tgbot/types/forum/ForumTopicReopened;
+	public final fun component68 ()Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;
+	public final fun component69 ()Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;
+	public final fun component7 ()Lkotlinx/datetime/Instant;
+	public final fun component70 ()Leu/vendeli/tgbot/types/GiveawayCreated;
+	public final fun component71 ()Leu/vendeli/tgbot/types/Giveaway;
+	public final fun component72 ()Leu/vendeli/tgbot/types/GiveawayWinners;
+	public final fun component73 ()Leu/vendeli/tgbot/types/GiveawayCompleted;
+	public final fun component74 ()Leu/vendeli/tgbot/types/media/VideoChatScheduled;
+	public final fun component75 ()Leu/vendeli/tgbot/types/media/VideoChatStarted;
+	public final fun component76 ()Leu/vendeli/tgbot/types/media/VideoChatEnded;
+	public final fun component77 ()Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;
+	public final fun component78 ()Leu/vendeli/tgbot/types/keyboard/WebAppData;
+	public final fun component79 ()Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component80 ()Ljava/lang/Boolean;
+	public final fun component9 ()Leu/vendeli/tgbot/types/chat/Chat;
+	public final fun copy (JLjava/lang/Integer;Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/chat/Chat;Ljava/lang/Integer;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/String;Leu/vendeli/tgbot/types/chat/Chat;Leu/vendeli/tgbot/types/MessageOrigin;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/ExternalReplyInfo;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/TextQuote;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;Leu/vendeli/tgbot/types/media/Animation;Leu/vendeli/tgbot/types/media/Audio;Leu/vendeli/tgbot/types/media/Document;Ljava/util/List;Leu/vendeli/tgbot/types/media/Sticker;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/media/Video;Leu/vendeli/tgbot/types/media/VideoNote;Leu/vendeli/tgbot/types/media/Voice;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/Contact;Leu/vendeli/tgbot/types/game/Dice;Leu/vendeli/tgbot/types/game/Game;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/Venue;Leu/vendeli/tgbot/types/Location;Ljava/util/List;Leu/vendeli/tgbot/types/User;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;Ljava/lang/Long;Ljava/lang/Long;Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;Leu/vendeli/tgbot/types/payment/Invoice;Leu/vendeli/tgbot/types/payment/SuccessfulPayment;Leu/vendeli/tgbot/types/UsersShared;Leu/vendeli/tgbot/types/chat/ChatShared;Ljava/lang/String;Leu/vendeli/tgbot/types/WriteAccessAllowed;Leu/vendeli/tgbot/types/passport/PassportData;Leu/vendeli/tgbot/types/ProximityAlertTriggered;Leu/vendeli/tgbot/types/boost/ChatBoostAdded;Leu/vendeli/tgbot/types/forum/ForumTopicCreated;Leu/vendeli/tgbot/types/forum/ForumTopicEdited;Leu/vendeli/tgbot/types/forum/ForumTopicClosed;Leu/vendeli/tgbot/types/forum/ForumTopicReopened;Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;Leu/vendeli/tgbot/types/GiveawayCreated;Leu/vendeli/tgbot/types/Giveaway;Leu/vendeli/tgbot/types/GiveawayWinners;Leu/vendeli/tgbot/types/GiveawayCompleted;Leu/vendeli/tgbot/types/media/VideoChatScheduled;Leu/vendeli/tgbot/types/media/VideoChatStarted;Leu/vendeli/tgbot/types/media/VideoChatEnded;Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;Leu/vendeli/tgbot/types/keyboard/WebAppData;Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/Message;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/Message;JLjava/lang/Integer;Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/chat/Chat;Ljava/lang/Integer;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/String;Leu/vendeli/tgbot/types/chat/Chat;Leu/vendeli/tgbot/types/MessageOrigin;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/ExternalReplyInfo;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/TextQuote;Leu/vendeli/tgbot/types/User;Lkotlinx/datetime/Instant;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;Leu/vendeli/tgbot/types/media/Animation;Leu/vendeli/tgbot/types/media/Audio;Leu/vendeli/tgbot/types/media/Document;Ljava/util/List;Leu/vendeli/tgbot/types/media/Sticker;Leu/vendeli/tgbot/types/media/Story;Leu/vendeli/tgbot/types/media/Video;Leu/vendeli/tgbot/types/media/VideoNote;Leu/vendeli/tgbot/types/media/Voice;Ljava/lang/String;Ljava/util/List;Leu/vendeli/tgbot/types/Contact;Leu/vendeli/tgbot/types/game/Dice;Leu/vendeli/tgbot/types/game/Game;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/Venue;Leu/vendeli/tgbot/types/Location;Ljava/util/List;Leu/vendeli/tgbot/types/User;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged;Ljava/lang/Long;Ljava/lang/Long;Leu/vendeli/tgbot/types/MaybeInaccessibleMessage;Leu/vendeli/tgbot/types/payment/Invoice;Leu/vendeli/tgbot/types/payment/SuccessfulPayment;Leu/vendeli/tgbot/types/UsersShared;Leu/vendeli/tgbot/types/chat/ChatShared;Ljava/lang/String;Leu/vendeli/tgbot/types/WriteAccessAllowed;Leu/vendeli/tgbot/types/passport/PassportData;Leu/vendeli/tgbot/types/ProximityAlertTriggered;Leu/vendeli/tgbot/types/boost/ChatBoostAdded;Leu/vendeli/tgbot/types/forum/ForumTopicCreated;Leu/vendeli/tgbot/types/forum/ForumTopicEdited;Leu/vendeli/tgbot/types/forum/ForumTopicClosed;Leu/vendeli/tgbot/types/forum/ForumTopicReopened;Leu/vendeli/tgbot/types/forum/GeneralForumTopicHidden;Leu/vendeli/tgbot/types/forum/GeneralForumTopicUnhidden;Leu/vendeli/tgbot/types/GiveawayCreated;Leu/vendeli/tgbot/types/Giveaway;Leu/vendeli/tgbot/types/GiveawayWinners;Leu/vendeli/tgbot/types/GiveawayCompleted;Leu/vendeli/tgbot/types/media/VideoChatScheduled;Leu/vendeli/tgbot/types/media/VideoChatStarted;Leu/vendeli/tgbot/types/media/VideoChatEnded;Leu/vendeli/tgbot/types/media/VideoChatParticipantsInvited;Leu/vendeli/tgbot/types/keyboard/WebAppData;Leu/vendeli/tgbot/types/keyboard/InlineKeyboardMarkup;Ljava/lang/Boolean;IIILjava/lang/Object;)Leu/vendeli/tgbot/types/Message;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnimation ()Leu/vendeli/tgbot/types/media/Animation;
 	public final fun getAudio ()Leu/vendeli/tgbot/types/media/Audio;
 	public final fun getAuthorSignature ()Ljava/lang/String;
 	public final fun getBoostAdded ()Leu/vendeli/tgbot/types/boost/ChatBoostAdded;
+	public final fun getBusinessConnectionId ()Ljava/lang/String;
 	public final fun getCaption ()Ljava/lang/String;
 	public final fun getCaptionEntities ()Ljava/util/List;
 	public final fun getChannelChatCreated ()Ljava/lang/Boolean;
@@ -3090,6 +3227,7 @@ public final class eu/vendeli/tgbot/types/Message : eu/vendeli/tgbot/types/Maybe
 	public final fun getReplyToMessage ()Leu/vendeli/tgbot/types/Message;
 	public final fun getReplyToStory ()Leu/vendeli/tgbot/types/media/Story;
 	public final fun getSenderBoostCount ()Ljava/lang/Integer;
+	public final fun getSenderBusinessBot ()Leu/vendeli/tgbot/types/User;
 	public final fun getSenderChat ()Leu/vendeli/tgbot/types/chat/Chat;
 	public final fun getSticker ()Leu/vendeli/tgbot/types/media/Sticker;
 	public final fun getStory ()Leu/vendeli/tgbot/types/media/Story;
@@ -3110,6 +3248,7 @@ public final class eu/vendeli/tgbot/types/Message : eu/vendeli/tgbot/types/Maybe
 	public final fun getWriteAccessAllowed ()Leu/vendeli/tgbot/types/WriteAccessAllowed;
 	public fun hashCode ()I
 	public final fun isAutomaticForward ()Ljava/lang/Boolean;
+	public final fun isFromOffline ()Ljava/lang/Boolean;
 	public final fun isTopicMessage ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
 }
@@ -3825,6 +3964,42 @@ public final class eu/vendeli/tgbot/types/SentWebAppMessage$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class eu/vendeli/tgbot/types/SharedUser {
+	public static final field Companion Leu/vendeli/tgbot/types/SharedUser$Companion;
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Leu/vendeli/tgbot/types/SharedUser;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/SharedUser;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Leu/vendeli/tgbot/types/SharedUser;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFirstName ()Ljava/lang/String;
+	public final fun getLastName ()Ljava/lang/String;
+	public final fun getPhoto ()Ljava/util/List;
+	public final fun getUserId ()J
+	public final fun getUsername ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/SharedUser$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Leu/vendeli/tgbot/types/SharedUser$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/SharedUser;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/SharedUser;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/SharedUser$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class eu/vendeli/tgbot/types/Text : eu/vendeli/tgbot/types/InputMessageContent {
 	public static final field Companion Leu/vendeli/tgbot/types/Text$Companion;
 	public fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/ParseMode;Ljava/util/List;Leu/vendeli/tgbot/types/LinkPreviewOptions;)V
@@ -3895,36 +4070,44 @@ public final class eu/vendeli/tgbot/types/TextQuote$Companion {
 
 public final class eu/vendeli/tgbot/types/Update : eu/vendeli/tgbot/interfaces/MultipleResponse {
 	public static final field Companion Leu/vendeli/tgbot/types/Update$Companion;
-	public fun <init> (ILeu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/MessageReactionUpdated;Leu/vendeli/tgbot/types/MessageReactionCountUpdated;Leu/vendeli/tgbot/types/inline/InlineQuery;Leu/vendeli/tgbot/types/inline/ChosenInlineResult;Leu/vendeli/tgbot/types/CallbackQuery;Leu/vendeli/tgbot/types/payment/ShippingQuery;Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/PollAnswer;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatJoinRequest;Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;)V
-	public synthetic fun <init> (ILeu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/MessageReactionUpdated;Leu/vendeli/tgbot/types/MessageReactionCountUpdated;Leu/vendeli/tgbot/types/inline/InlineQuery;Leu/vendeli/tgbot/types/inline/ChosenInlineResult;Leu/vendeli/tgbot/types/CallbackQuery;Leu/vendeli/tgbot/types/payment/ShippingQuery;Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/PollAnswer;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatJoinRequest;Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILeu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/business/BusinessConnection;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;Leu/vendeli/tgbot/types/MessageReactionUpdated;Leu/vendeli/tgbot/types/MessageReactionCountUpdated;Leu/vendeli/tgbot/types/inline/InlineQuery;Leu/vendeli/tgbot/types/inline/ChosenInlineResult;Leu/vendeli/tgbot/types/CallbackQuery;Leu/vendeli/tgbot/types/payment/ShippingQuery;Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/PollAnswer;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatJoinRequest;Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;)V
+	public synthetic fun <init> (ILeu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/business/BusinessConnection;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;Leu/vendeli/tgbot/types/MessageReactionUpdated;Leu/vendeli/tgbot/types/MessageReactionCountUpdated;Leu/vendeli/tgbot/types/inline/InlineQuery;Leu/vendeli/tgbot/types/inline/ChosenInlineResult;Leu/vendeli/tgbot/types/CallbackQuery;Leu/vendeli/tgbot/types/payment/ShippingQuery;Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/PollAnswer;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatJoinRequest;Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
-	public final fun component10 ()Leu/vendeli/tgbot/types/CallbackQuery;
-	public final fun component11 ()Leu/vendeli/tgbot/types/payment/ShippingQuery;
-	public final fun component12 ()Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;
-	public final fun component13 ()Leu/vendeli/tgbot/types/Poll;
-	public final fun component14 ()Leu/vendeli/tgbot/types/PollAnswer;
-	public final fun component15 ()Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;
-	public final fun component16 ()Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;
-	public final fun component17 ()Leu/vendeli/tgbot/types/chat/ChatJoinRequest;
-	public final fun component18 ()Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;
-	public final fun component19 ()Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;
+	public final fun component10 ()Leu/vendeli/tgbot/types/MessageReactionUpdated;
+	public final fun component11 ()Leu/vendeli/tgbot/types/MessageReactionCountUpdated;
+	public final fun component12 ()Leu/vendeli/tgbot/types/inline/InlineQuery;
+	public final fun component13 ()Leu/vendeli/tgbot/types/inline/ChosenInlineResult;
+	public final fun component14 ()Leu/vendeli/tgbot/types/CallbackQuery;
+	public final fun component15 ()Leu/vendeli/tgbot/types/payment/ShippingQuery;
+	public final fun component16 ()Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;
+	public final fun component17 ()Leu/vendeli/tgbot/types/Poll;
+	public final fun component18 ()Leu/vendeli/tgbot/types/PollAnswer;
+	public final fun component19 ()Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;
 	public final fun component2 ()Leu/vendeli/tgbot/types/Message;
+	public final fun component20 ()Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;
+	public final fun component21 ()Leu/vendeli/tgbot/types/chat/ChatJoinRequest;
+	public final fun component22 ()Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;
+	public final fun component23 ()Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;
 	public final fun component3 ()Leu/vendeli/tgbot/types/Message;
 	public final fun component4 ()Leu/vendeli/tgbot/types/Message;
 	public final fun component5 ()Leu/vendeli/tgbot/types/Message;
-	public final fun component6 ()Leu/vendeli/tgbot/types/MessageReactionUpdated;
-	public final fun component7 ()Leu/vendeli/tgbot/types/MessageReactionCountUpdated;
-	public final fun component8 ()Leu/vendeli/tgbot/types/inline/InlineQuery;
-	public final fun component9 ()Leu/vendeli/tgbot/types/inline/ChosenInlineResult;
-	public final fun copy (ILeu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/MessageReactionUpdated;Leu/vendeli/tgbot/types/MessageReactionCountUpdated;Leu/vendeli/tgbot/types/inline/InlineQuery;Leu/vendeli/tgbot/types/inline/ChosenInlineResult;Leu/vendeli/tgbot/types/CallbackQuery;Leu/vendeli/tgbot/types/payment/ShippingQuery;Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/PollAnswer;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatJoinRequest;Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;)Leu/vendeli/tgbot/types/Update;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/Update;ILeu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/MessageReactionUpdated;Leu/vendeli/tgbot/types/MessageReactionCountUpdated;Leu/vendeli/tgbot/types/inline/InlineQuery;Leu/vendeli/tgbot/types/inline/ChosenInlineResult;Leu/vendeli/tgbot/types/CallbackQuery;Leu/vendeli/tgbot/types/payment/ShippingQuery;Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/PollAnswer;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatJoinRequest;Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;ILjava/lang/Object;)Leu/vendeli/tgbot/types/Update;
+	public final fun component6 ()Leu/vendeli/tgbot/types/business/BusinessConnection;
+	public final fun component7 ()Leu/vendeli/tgbot/types/Message;
+	public final fun component8 ()Leu/vendeli/tgbot/types/Message;
+	public final fun component9 ()Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;
+	public final fun copy (ILeu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/business/BusinessConnection;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;Leu/vendeli/tgbot/types/MessageReactionUpdated;Leu/vendeli/tgbot/types/MessageReactionCountUpdated;Leu/vendeli/tgbot/types/inline/InlineQuery;Leu/vendeli/tgbot/types/inline/ChosenInlineResult;Leu/vendeli/tgbot/types/CallbackQuery;Leu/vendeli/tgbot/types/payment/ShippingQuery;Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/PollAnswer;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatJoinRequest;Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;)Leu/vendeli/tgbot/types/Update;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/Update;ILeu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/business/BusinessConnection;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;Leu/vendeli/tgbot/types/MessageReactionUpdated;Leu/vendeli/tgbot/types/MessageReactionCountUpdated;Leu/vendeli/tgbot/types/inline/InlineQuery;Leu/vendeli/tgbot/types/inline/ChosenInlineResult;Leu/vendeli/tgbot/types/CallbackQuery;Leu/vendeli/tgbot/types/payment/ShippingQuery;Leu/vendeli/tgbot/types/payment/PreCheckoutQuery;Leu/vendeli/tgbot/types/Poll;Leu/vendeli/tgbot/types/PollAnswer;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;Leu/vendeli/tgbot/types/chat/ChatJoinRequest;Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;Leu/vendeli/tgbot/types/boost/ChatBoostRemoved;ILjava/lang/Object;)Leu/vendeli/tgbot/types/Update;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBusinessConnection ()Leu/vendeli/tgbot/types/business/BusinessConnection;
+	public final fun getBusinessMessage ()Leu/vendeli/tgbot/types/Message;
 	public final fun getCallbackQuery ()Leu/vendeli/tgbot/types/CallbackQuery;
 	public final fun getChannelPost ()Leu/vendeli/tgbot/types/Message;
 	public final fun getChatBoost ()Leu/vendeli/tgbot/types/boost/ChatBoostUpdated;
 	public final fun getChatJoinRequest ()Leu/vendeli/tgbot/types/chat/ChatJoinRequest;
 	public final fun getChatMember ()Leu/vendeli/tgbot/types/chat/ChatMemberUpdated;
 	public final fun getChosenInlineResult ()Leu/vendeli/tgbot/types/inline/ChosenInlineResult;
+	public final fun getDeletedBusinessMessages ()Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;
+	public final fun getEditedBusinessMessage ()Leu/vendeli/tgbot/types/Message;
 	public final fun getEditedChannelPost ()Leu/vendeli/tgbot/types/Message;
 	public final fun getEditedMessage ()Leu/vendeli/tgbot/types/Message;
 	public final fun getInlineQuery ()Leu/vendeli/tgbot/types/inline/InlineQuery;
@@ -3959,11 +4142,12 @@ public final class eu/vendeli/tgbot/types/Update$Companion {
 
 public final class eu/vendeli/tgbot/types/User {
 	public static final field Companion Leu/vendeli/tgbot/types/User$Companion;
-	public fun <init> (JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component10 ()Ljava/lang/Boolean;
 	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/Boolean;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -3972,10 +4156,11 @@ public final class eu/vendeli/tgbot/types/User {
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/User;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/User;JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Leu/vendeli/tgbot/types/User;
+	public final fun copy (JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/User;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/User;JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Leu/vendeli/tgbot/types/User;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddedToAttachmentMenu ()Ljava/lang/Boolean;
+	public final fun getCanConnectToBusiness ()Ljava/lang/Boolean;
 	public final fun getCanJoinGroups ()Ljava/lang/Boolean;
 	public final fun getCanReadAllGroupMessages ()Ljava/lang/Boolean;
 	public final fun getFirstName ()Ljava/lang/String;
@@ -4043,7 +4228,7 @@ public final class eu/vendeli/tgbot/types/UsersShared {
 	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/UsersShared;ILjava/util/List;ILjava/lang/Object;)Leu/vendeli/tgbot/types/UsersShared;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestId ()I
-	public final fun getUserId ()Ljava/util/List;
+	public final fun getUsers ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -4755,55 +4940,253 @@ public final class eu/vendeli/tgbot/types/bot/BotShortDescription$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class eu/vendeli/tgbot/types/business/BusinessConnection {
+	public static final field Companion Leu/vendeli/tgbot/types/business/BusinessConnection$Companion;
+	public fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/User;JJZZ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Leu/vendeli/tgbot/types/User;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun copy (Ljava/lang/String;Leu/vendeli/tgbot/types/User;JJZZ)Leu/vendeli/tgbot/types/business/BusinessConnection;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/business/BusinessConnection;Ljava/lang/String;Leu/vendeli/tgbot/types/User;JJZZILjava/lang/Object;)Leu/vendeli/tgbot/types/business/BusinessConnection;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCanReply ()Z
+	public final fun getDate ()J
+	public final fun getId ()Ljava/lang/String;
+	public final fun getUser ()Leu/vendeli/tgbot/types/User;
+	public final fun getUserChatId ()J
+	public fun hashCode ()I
+	public final fun isEnabled ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessConnection$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Leu/vendeli/tgbot/types/business/BusinessConnection$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/business/BusinessConnection;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/business/BusinessConnection;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessConnection$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessIntro {
+	public static final field Companion Leu/vendeli/tgbot/types/business/BusinessIntro$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/Sticker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/Sticker;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Leu/vendeli/tgbot/types/media/Sticker;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/Sticker;)Leu/vendeli/tgbot/types/business/BusinessIntro;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/business/BusinessIntro;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/Sticker;ILjava/lang/Object;)Leu/vendeli/tgbot/types/business/BusinessIntro;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getSticker ()Leu/vendeli/tgbot/types/media/Sticker;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessIntro$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Leu/vendeli/tgbot/types/business/BusinessIntro$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/business/BusinessIntro;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/business/BusinessIntro;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessIntro$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessLocation {
+	public static final field Companion Leu/vendeli/tgbot/types/business/BusinessLocation$Companion;
+	public fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/Location;)V
+	public synthetic fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/Location;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Leu/vendeli/tgbot/types/Location;
+	public final fun copy (Ljava/lang/String;Leu/vendeli/tgbot/types/Location;)Leu/vendeli/tgbot/types/business/BusinessLocation;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/business/BusinessLocation;Ljava/lang/String;Leu/vendeli/tgbot/types/Location;ILjava/lang/Object;)Leu/vendeli/tgbot/types/business/BusinessLocation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Ljava/lang/String;
+	public final fun getLocation ()Leu/vendeli/tgbot/types/Location;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessLocation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Leu/vendeli/tgbot/types/business/BusinessLocation$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/business/BusinessLocation;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/business/BusinessLocation;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessLocation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessMessagesDeleted {
+	public static final field Companion Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted$Companion;
+	public fun <init> (Ljava/lang/String;Leu/vendeli/tgbot/types/chat/Chat;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Leu/vendeli/tgbot/types/chat/Chat;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Leu/vendeli/tgbot/types/chat/Chat;Ljava/util/List;)Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;Ljava/lang/String;Leu/vendeli/tgbot/types/chat/Chat;Ljava/util/List;ILjava/lang/Object;)Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBusinessConnectionId ()Ljava/lang/String;
+	public final fun getChat ()Leu/vendeli/tgbot/types/chat/Chat;
+	public final fun getMessageIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessMessagesDeleted$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessMessagesDeleted$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessOpeningHours {
+	public static final field Companion Leu/vendeli/tgbot/types/business/BusinessOpeningHours$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Leu/vendeli/tgbot/types/business/BusinessOpeningHours;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/business/BusinessOpeningHours;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Leu/vendeli/tgbot/types/business/BusinessOpeningHours;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOpeningHours ()Ljava/util/List;
+	public final fun getTimeZoneName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessOpeningHours$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Leu/vendeli/tgbot/types/business/BusinessOpeningHours$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/business/BusinessOpeningHours;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/business/BusinessOpeningHours;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessOpeningHours$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval {
+	public static final field Companion Leu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval$Companion;
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Leu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval;IIILjava/lang/Object;)Leu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClosingMinute ()I
+	public final fun getOpeningMinute ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Leu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class eu/vendeli/tgbot/types/chat/Chat {
 	public static final field Companion Leu/vendeli/tgbot/types/chat/Chat$Companion;
-	public fun <init> (JLeu/vendeli/tgbot/types/chat/ChatType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatPhoto;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/chat/ChatPermissions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Long;Leu/vendeli/tgbot/types/chat/ChatLocation;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (JLeu/vendeli/tgbot/types/chat/ChatType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatPhoto;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/chat/ChatPermissions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Long;Leu/vendeli/tgbot/types/chat/ChatLocation;Ljava/lang/Boolean;Ljava/lang/Boolean;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JLeu/vendeli/tgbot/types/chat/ChatType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatPhoto;Ljava/util/List;Leu/vendeli/tgbot/types/Birthdate;Leu/vendeli/tgbot/types/business/BusinessIntro;Leu/vendeli/tgbot/types/business/BusinessLocation;Leu/vendeli/tgbot/types/business/BusinessOpeningHours;Leu/vendeli/tgbot/types/chat/Chat;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/chat/ChatPermissions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Long;Leu/vendeli/tgbot/types/chat/ChatLocation;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (JLeu/vendeli/tgbot/types/chat/ChatType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatPhoto;Ljava/util/List;Leu/vendeli/tgbot/types/Birthdate;Leu/vendeli/tgbot/types/business/BusinessIntro;Leu/vendeli/tgbot/types/business/BusinessLocation;Leu/vendeli/tgbot/types/business/BusinessOpeningHours;Leu/vendeli/tgbot/types/chat/Chat;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/chat/ChatPermissions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Long;Leu/vendeli/tgbot/types/chat/ChatLocation;Ljava/lang/Boolean;Ljava/lang/Boolean;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
-	public final fun component10 ()Ljava/util/List;
-	public final fun component11 ()Ljava/lang/Integer;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component13 ()Ljava/lang/Integer;
-	public final fun component14 ()Ljava/lang/String;
-	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()Lkotlinx/datetime/Instant;
+	public final fun component10 ()Leu/vendeli/tgbot/types/Birthdate;
+	public final fun component11 ()Leu/vendeli/tgbot/types/business/BusinessIntro;
+	public final fun component12 ()Leu/vendeli/tgbot/types/business/BusinessLocation;
+	public final fun component13 ()Leu/vendeli/tgbot/types/business/BusinessOpeningHours;
+	public final fun component14 ()Leu/vendeli/tgbot/types/chat/Chat;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/lang/Integer;
 	public final fun component17 ()Ljava/lang/String;
-	public final fun component18 ()Ljava/lang/Boolean;
-	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component18 ()Ljava/lang/Integer;
+	public final fun component19 ()Ljava/lang/String;
 	public final fun component2 ()Leu/vendeli/tgbot/types/chat/ChatType;
-	public final fun component20 ()Ljava/lang/Boolean;
-	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Lkotlinx/datetime/Instant;
 	public final fun component22 ()Ljava/lang/String;
-	public final fun component23 ()Ljava/lang/String;
-	public final fun component24 ()Leu/vendeli/tgbot/types/Message;
-	public final fun component25 ()Leu/vendeli/tgbot/types/chat/ChatPermissions;
-	public final fun component26 ()Ljava/lang/Integer;
-	public final fun component27 ()Ljava/lang/Integer;
-	public final fun component28 ()Ljava/lang/Integer;
-	public final fun component29 ()Ljava/lang/Boolean;
+	public final fun component23 ()Ljava/lang/Boolean;
+	public final fun component24 ()Ljava/lang/Boolean;
+	public final fun component25 ()Ljava/lang/Boolean;
+	public final fun component26 ()Ljava/lang/Boolean;
+	public final fun component27 ()Ljava/lang/String;
+	public final fun component28 ()Ljava/lang/String;
+	public final fun component29 ()Leu/vendeli/tgbot/types/Message;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component30 ()Ljava/lang/Boolean;
-	public final fun component31 ()Ljava/lang/String;
-	public final fun component32 ()Ljava/lang/Boolean;
-	public final fun component33 ()Ljava/lang/String;
-	public final fun component34 ()Ljava/lang/Long;
-	public final fun component35 ()Leu/vendeli/tgbot/types/chat/ChatLocation;
-	public final fun component36 ()Ljava/lang/Boolean;
+	public final fun component30 ()Leu/vendeli/tgbot/types/chat/ChatPermissions;
+	public final fun component31 ()Ljava/lang/Integer;
+	public final fun component32 ()Ljava/lang/Integer;
+	public final fun component33 ()Ljava/lang/Integer;
+	public final fun component34 ()Ljava/lang/Boolean;
+	public final fun component35 ()Ljava/lang/Boolean;
+	public final fun component36 ()Ljava/lang/String;
 	public final fun component37 ()Ljava/lang/Boolean;
+	public final fun component38 ()Ljava/lang/String;
+	public final fun component39 ()Ljava/lang/Long;
 	public final fun component4 ()Ljava/lang/String;
+	public final fun component40 ()Leu/vendeli/tgbot/types/chat/ChatLocation;
+	public final fun component41 ()Ljava/lang/Boolean;
+	public final fun component42 ()Ljava/lang/Boolean;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Leu/vendeli/tgbot/types/chat/ChatPhoto;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (JLeu/vendeli/tgbot/types/chat/ChatType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatPhoto;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/chat/ChatPermissions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Long;Leu/vendeli/tgbot/types/chat/ChatLocation;Ljava/lang/Boolean;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/chat/Chat;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/chat/Chat;JLeu/vendeli/tgbot/types/chat/ChatType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatPhoto;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/chat/ChatPermissions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Long;Leu/vendeli/tgbot/types/chat/ChatLocation;Ljava/lang/Boolean;Ljava/lang/Boolean;IILjava/lang/Object;)Leu/vendeli/tgbot/types/chat/Chat;
+	public final fun copy (JLeu/vendeli/tgbot/types/chat/ChatType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatPhoto;Ljava/util/List;Leu/vendeli/tgbot/types/Birthdate;Leu/vendeli/tgbot/types/business/BusinessIntro;Leu/vendeli/tgbot/types/business/BusinessLocation;Leu/vendeli/tgbot/types/business/BusinessOpeningHours;Leu/vendeli/tgbot/types/chat/Chat;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/chat/ChatPermissions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Long;Leu/vendeli/tgbot/types/chat/ChatLocation;Ljava/lang/Boolean;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/chat/Chat;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/chat/Chat;JLeu/vendeli/tgbot/types/chat/ChatType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatPhoto;Ljava/util/List;Leu/vendeli/tgbot/types/Birthdate;Leu/vendeli/tgbot/types/business/BusinessIntro;Leu/vendeli/tgbot/types/business/BusinessLocation;Leu/vendeli/tgbot/types/business/BusinessOpeningHours;Leu/vendeli/tgbot/types/chat/Chat;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/Message;Leu/vendeli/tgbot/types/chat/ChatPermissions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Long;Leu/vendeli/tgbot/types/chat/ChatLocation;Ljava/lang/Boolean;Ljava/lang/Boolean;IILjava/lang/Object;)Leu/vendeli/tgbot/types/chat/Chat;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccentColorId ()Ljava/lang/Integer;
 	public final fun getActiveUsernames ()Ljava/util/List;
 	public final fun getAvailableReactions ()Ljava/util/List;
 	public final fun getBackgroundCustomEmojiId ()Ljava/lang/String;
 	public final fun getBio ()Ljava/lang/String;
+	public final fun getBirthdate ()Leu/vendeli/tgbot/types/Birthdate;
+	public final fun getBusinessIntro ()Leu/vendeli/tgbot/types/business/BusinessIntro;
+	public final fun getBusinessLocation ()Leu/vendeli/tgbot/types/business/BusinessLocation;
+	public final fun getBusinessOpeningHours ()Leu/vendeli/tgbot/types/business/BusinessOpeningHours;
 	public final fun getCanSetStickerSet ()Ljava/lang/Boolean;
 	public final fun getCustomEmojiStickerSetName ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
@@ -4825,6 +5208,7 @@ public final class eu/vendeli/tgbot/types/chat/Chat {
 	public final fun getLocation ()Leu/vendeli/tgbot/types/chat/ChatLocation;
 	public final fun getMessageAutoDeleteTime ()Ljava/lang/Integer;
 	public final fun getPermissions ()Leu/vendeli/tgbot/types/chat/ChatPermissions;
+	public final fun getPersonalChat ()Leu/vendeli/tgbot/types/chat/Chat;
 	public final fun getPhoto ()Leu/vendeli/tgbot/types/chat/ChatPhoto;
 	public final fun getPinnedMessage ()Leu/vendeli/tgbot/types/Message;
 	public final fun getProfileAccentColorId ()Ljava/lang/Integer;
@@ -5434,14 +5818,21 @@ public final class eu/vendeli/tgbot/types/chat/ChatPhoto$Companion {
 
 public final class eu/vendeli/tgbot/types/chat/ChatShared {
 	public static final field Companion Leu/vendeli/tgbot/types/chat/ChatShared$Companion;
-	public fun <init> (IJ)V
+	public fun <init> (IJLjava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (IJLjava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()J
-	public final fun copy (IJ)Leu/vendeli/tgbot/types/chat/ChatShared;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/chat/ChatShared;IJILjava/lang/Object;)Leu/vendeli/tgbot/types/chat/ChatShared;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (IJLjava/lang/String;Ljava/lang/String;Ljava/util/List;)Leu/vendeli/tgbot/types/chat/ChatShared;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/chat/ChatShared;IJLjava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Leu/vendeli/tgbot/types/chat/ChatShared;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChatId ()J
+	public final fun getPhoto ()Ljava/util/List;
 	public final fun getRequestId ()I
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUsername ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -6803,21 +7194,52 @@ public abstract interface class eu/vendeli/tgbot/types/internal/Action {
 }
 
 public final class eu/vendeli/tgbot/types/internal/ActivityCtx {
-	public static final synthetic fun box-impl (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;)Leu/vendeli/tgbot/types/internal/ActivityCtx;
-	public static fun constructor-impl (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;)Leu/vendeli/tgbot/types/internal/ProcessedUpdate;
+	public fun <init> (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;)V
+	public final fun component1 ()Leu/vendeli/tgbot/types/internal/ProcessedUpdate;
+	public final fun copy (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;)Leu/vendeli/tgbot/types/internal/ActivityCtx;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/internal/ActivityCtx;Leu/vendeli/tgbot/types/internal/ProcessedUpdate;ILjava/lang/Object;)Leu/vendeli/tgbot/types/internal/ActivityCtx;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;Leu/vendeli/tgbot/types/internal/ProcessedUpdate;)Z
 	public final fun getUpdate ()Leu/vendeli/tgbot/types/internal/ProcessedUpdate;
+	public final fun getUser ()Leu/vendeli/tgbot/types/User;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Leu/vendeli/tgbot/types/internal/ProcessedUpdate;
 }
 
 public abstract interface class eu/vendeli/tgbot/types/internal/BreakCondition {
 	public abstract fun invoke (Leu/vendeli/tgbot/types/User;Leu/vendeli/tgbot/types/internal/ProcessedUpdate;Leu/vendeli/tgbot/TelegramBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class eu/vendeli/tgbot/types/internal/BusinessConnectionUpdate : eu/vendeli/tgbot/types/internal/ProcessedUpdate, eu/vendeli/tgbot/types/internal/UserReference {
+	public fun <init> (ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/business/BusinessConnection;)V
+	public final fun component1 ()I
+	public final fun component2 ()Leu/vendeli/tgbot/types/Update;
+	public final fun component3 ()Leu/vendeli/tgbot/types/business/BusinessConnection;
+	public final fun copy (ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/business/BusinessConnection;)Leu/vendeli/tgbot/types/internal/BusinessConnectionUpdate;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/internal/BusinessConnectionUpdate;ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/business/BusinessConnection;ILjava/lang/Object;)Leu/vendeli/tgbot/types/internal/BusinessConnectionUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBusinessConnection ()Leu/vendeli/tgbot/types/business/BusinessConnection;
+	public fun getUpdate ()Leu/vendeli/tgbot/types/Update;
+	public fun getUpdateId ()I
+	public fun getUser ()Leu/vendeli/tgbot/types/User;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/internal/BusinessMessageUpdate : eu/vendeli/tgbot/types/internal/ProcessedUpdate, eu/vendeli/tgbot/types/internal/UserReference {
+	public fun <init> (ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/Message;)V
+	public final fun component1 ()I
+	public final fun component2 ()Leu/vendeli/tgbot/types/Update;
+	public final fun component3 ()Leu/vendeli/tgbot/types/Message;
+	public final fun copy (ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/Message;)Leu/vendeli/tgbot/types/internal/BusinessMessageUpdate;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/internal/BusinessMessageUpdate;ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/Message;ILjava/lang/Object;)Leu/vendeli/tgbot/types/internal/BusinessMessageUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBusinessMessage ()Leu/vendeli/tgbot/types/Message;
+	public fun getText ()Ljava/lang/String;
+	public fun getUpdate ()Leu/vendeli/tgbot/types/Update;
+	public fun getUpdateId ()I
+	public fun getUser ()Leu/vendeli/tgbot/types/User;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class eu/vendeli/tgbot/types/internal/CallbackQueryUpdate : eu/vendeli/tgbot/types/internal/ProcessedUpdate, eu/vendeli/tgbot/types/internal/UserReference {
@@ -6927,7 +7349,6 @@ public final class eu/vendeli/tgbot/types/internal/ChosenInlineResultUpdate : eu
 }
 
 public final class eu/vendeli/tgbot/types/internal/CommandContext {
-	public static final field Companion Leu/vendeli/tgbot/types/internal/CommandContext$Companion;
 	public fun <init> (Leu/vendeli/tgbot/types/internal/ProcessedUpdate;Ljava/util/Map;)V
 	public final fun component1 ()Leu/vendeli/tgbot/types/internal/ProcessedUpdate;
 	public final fun component2 ()Ljava/util/Map;
@@ -6936,23 +7357,9 @@ public final class eu/vendeli/tgbot/types/internal/CommandContext {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getParameters ()Ljava/util/Map;
 	public final fun getUpdate ()Leu/vendeli/tgbot/types/internal/ProcessedUpdate;
+	public final fun getUser ()Leu/vendeli/tgbot/types/User;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class eu/vendeli/tgbot/types/internal/CommandContext$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;)V
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Leu/vendeli/tgbot/types/internal/CommandContext;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Leu/vendeli/tgbot/types/internal/CommandContext;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class eu/vendeli/tgbot/types/internal/CommandContext$Companion {
-	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 
 public final class eu/vendeli/tgbot/types/internal/Currency : java/lang/Enum {
@@ -7048,6 +7455,38 @@ public final class eu/vendeli/tgbot/types/internal/Currency : java/lang/Enum {
 
 public final class eu/vendeli/tgbot/types/internal/Currency$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class eu/vendeli/tgbot/types/internal/DeletedBusinessMessagesUpdate : eu/vendeli/tgbot/types/internal/ProcessedUpdate {
+	public fun <init> (ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;)V
+	public final fun component1 ()I
+	public final fun component2 ()Leu/vendeli/tgbot/types/Update;
+	public final fun component3 ()Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;
+	public final fun copy (ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;)Leu/vendeli/tgbot/types/internal/DeletedBusinessMessagesUpdate;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/internal/DeletedBusinessMessagesUpdate;ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;ILjava/lang/Object;)Leu/vendeli/tgbot/types/internal/DeletedBusinessMessagesUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeletedBusinessMessages ()Leu/vendeli/tgbot/types/business/BusinessMessagesDeleted;
+	public fun getUpdate ()Leu/vendeli/tgbot/types/Update;
+	public fun getUpdateId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class eu/vendeli/tgbot/types/internal/EditedBusinessMessageUpdate : eu/vendeli/tgbot/types/internal/ProcessedUpdate, eu/vendeli/tgbot/types/internal/UserReference {
+	public fun <init> (ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/Message;)V
+	public final fun component1 ()I
+	public final fun component2 ()Leu/vendeli/tgbot/types/Update;
+	public final fun component3 ()Leu/vendeli/tgbot/types/Message;
+	public final fun copy (ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/Message;)Leu/vendeli/tgbot/types/internal/EditedBusinessMessageUpdate;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/internal/EditedBusinessMessageUpdate;ILeu/vendeli/tgbot/types/Update;Leu/vendeli/tgbot/types/Message;ILjava/lang/Object;)Leu/vendeli/tgbot/types/internal/EditedBusinessMessageUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEditedBusinessMessage ()Leu/vendeli/tgbot/types/Message;
+	public fun getText ()Ljava/lang/String;
+	public fun getUpdate ()Leu/vendeli/tgbot/types/Update;
+	public fun getUpdateId ()I
+	public fun getUser ()Leu/vendeli/tgbot/types/User;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class eu/vendeli/tgbot/types/internal/EditedChannelPostUpdate : eu/vendeli/tgbot/types/internal/ProcessedUpdate, eu/vendeli/tgbot/types/internal/UserReference {
@@ -7544,6 +7983,8 @@ public final class eu/vendeli/tgbot/types/internal/TgMethod {
 }
 
 public final class eu/vendeli/tgbot/types/internal/UpdateType : java/lang/Enum {
+	public static final field BUSINESS_CONNECTION Leu/vendeli/tgbot/types/internal/UpdateType;
+	public static final field BUSINESS_MESSAGE Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field CALLBACK_QUERY Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field CHANNEL_POST Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field CHAT_BOOST Leu/vendeli/tgbot/types/internal/UpdateType;
@@ -7551,6 +7992,8 @@ public final class eu/vendeli/tgbot/types/internal/UpdateType : java/lang/Enum {
 	public static final field CHAT_MEMBER Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field CHOSEN_INLINE_RESULT Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field Companion Leu/vendeli/tgbot/types/internal/UpdateType$Companion;
+	public static final field DELETED_BUSINESS_MESSAGES Leu/vendeli/tgbot/types/internal/UpdateType;
+	public static final field EDITED_BUSINESS_MESSAGE Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field EDITED_CHANNEL_POST Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field EDIT_MESSAGE Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field INLINE_QUERY Leu/vendeli/tgbot/types/internal/UpdateType;
@@ -9506,9 +9949,11 @@ public final class eu/vendeli/tgbot/types/keyboard/KeyboardButtonPollType$Compan
 
 public final class eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat {
 	public static final field Companion Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat$Companion;
-	public fun <init> (IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/Boolean;
 	public final fun component4 ()Ljava/lang/Boolean;
@@ -9516,16 +9961,20 @@ public final class eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat {
 	public final fun component6 ()Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;
 	public final fun component7 ()Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;
 	public final fun component8 ()Ljava/lang/Boolean;
-	public final fun copy (IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat;IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Ljava/lang/Boolean;ILjava/lang/Object;)Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat;IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBotAdministratorRights ()Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;
 	public final fun getBotIsMember ()Ljava/lang/Boolean;
-	public final fun getChatHasUserName ()Ljava/lang/Boolean;
+	public final fun getChatHasUsername ()Ljava/lang/Boolean;
 	public final fun getChatIsChannel ()Z
 	public final fun getChatIsCreated ()Ljava/lang/Boolean;
 	public final fun getChatIsForum ()Ljava/lang/Boolean;
 	public final fun getRequestId ()I
+	public final fun getRequestPhoto ()Ljava/lang/Boolean;
+	public final fun getRequestTitle ()Ljava/lang/Boolean;
+	public final fun getRequestUsername ()Ljava/lang/Boolean;
 	public final fun getUserAdministratorRights ()Leu/vendeli/tgbot/types/chat/ChatAdministratorRights;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -9548,17 +9997,23 @@ public final class eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat$Com
 
 public final class eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers {
 	public static final field Companion Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers$Companion;
-	public fun <init> (ILjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)V
-	public synthetic fun <init> (ILjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ILjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/lang/Boolean;
 	public final fun component4 ()Ljava/lang/Integer;
-	public final fun copy (ILjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers;ILjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;ILjava/lang/Object;)Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun copy (ILjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers;ILjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Leu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMaxQuantity ()Ljava/lang/Integer;
 	public final fun getRequestId ()I
+	public final fun getRequestName ()Ljava/lang/Boolean;
+	public final fun getRequestPhoto ()Ljava/lang/Boolean;
+	public final fun getRequestUsername ()Ljava/lang/Boolean;
 	public final fun getUserIsBot ()Ljava/lang/Boolean;
 	public final fun getUserIsPremium ()Ljava/lang/Boolean;
 	public fun hashCode ()I
@@ -10202,16 +10657,18 @@ public final class eu/vendeli/tgbot/types/media/InputMedia$Video$Companion {
 
 public final class eu/vendeli/tgbot/types/media/InputSticker {
 	public static final field Companion Leu/vendeli/tgbot/types/media/InputSticker$Companion;
-	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;Ljava/util/List;Leu/vendeli/tgbot/types/media/MaskPosition;Ljava/util/List;)V
-	public synthetic fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;Ljava/util/List;Leu/vendeli/tgbot/types/media/MaskPosition;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;Leu/vendeli/tgbot/types/media/StickerFormat;Ljava/util/List;Leu/vendeli/tgbot/types/media/MaskPosition;Ljava/util/List;)V
+	public synthetic fun <init> (Leu/vendeli/tgbot/types/internal/ImplicitFile;Leu/vendeli/tgbot/types/media/StickerFormat;Ljava/util/List;Leu/vendeli/tgbot/types/media/MaskPosition;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Leu/vendeli/tgbot/types/internal/ImplicitFile;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Leu/vendeli/tgbot/types/media/MaskPosition;
-	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Leu/vendeli/tgbot/types/internal/ImplicitFile;Ljava/util/List;Leu/vendeli/tgbot/types/media/MaskPosition;Ljava/util/List;)Leu/vendeli/tgbot/types/media/InputSticker;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/media/InputSticker;Leu/vendeli/tgbot/types/internal/ImplicitFile;Ljava/util/List;Leu/vendeli/tgbot/types/media/MaskPosition;Ljava/util/List;ILjava/lang/Object;)Leu/vendeli/tgbot/types/media/InputSticker;
+	public final fun component2 ()Leu/vendeli/tgbot/types/media/StickerFormat;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Leu/vendeli/tgbot/types/media/MaskPosition;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Leu/vendeli/tgbot/types/internal/ImplicitFile;Leu/vendeli/tgbot/types/media/StickerFormat;Ljava/util/List;Leu/vendeli/tgbot/types/media/MaskPosition;Ljava/util/List;)Leu/vendeli/tgbot/types/media/InputSticker;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/media/InputSticker;Leu/vendeli/tgbot/types/internal/ImplicitFile;Leu/vendeli/tgbot/types/media/StickerFormat;Ljava/util/List;Leu/vendeli/tgbot/types/media/MaskPosition;Ljava/util/List;ILjava/lang/Object;)Leu/vendeli/tgbot/types/media/InputSticker;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmojiList ()Ljava/util/List;
+	public final fun getFormat ()Leu/vendeli/tgbot/types/media/StickerFormat;
 	public final fun getKeywords ()Ljava/util/List;
 	public final fun getMaskPosition ()Leu/vendeli/tgbot/types/media/MaskPosition;
 	public final fun getSticker ()Leu/vendeli/tgbot/types/internal/ImplicitFile;
@@ -10391,17 +10848,15 @@ public final class eu/vendeli/tgbot/types/media/StickerFormat$Companion {
 
 public final class eu/vendeli/tgbot/types/media/StickerSet {
 	public static final field Companion Leu/vendeli/tgbot/types/media/StickerSet$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerType;ZZLjava/util/List;Leu/vendeli/tgbot/types/media/PhotoSize;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerType;ZZLjava/util/List;Leu/vendeli/tgbot/types/media/PhotoSize;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerType;Ljava/util/List;Leu/vendeli/tgbot/types/media/PhotoSize;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerType;Ljava/util/List;Leu/vendeli/tgbot/types/media/PhotoSize;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Leu/vendeli/tgbot/types/media/StickerType;
-	public final fun component4 ()Z
-	public final fun component5 ()Z
-	public final fun component6 ()Ljava/util/List;
-	public final fun component7 ()Leu/vendeli/tgbot/types/media/PhotoSize;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerType;ZZLjava/util/List;Leu/vendeli/tgbot/types/media/PhotoSize;)Leu/vendeli/tgbot/types/media/StickerSet;
-	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/media/StickerSet;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerType;ZZLjava/util/List;Leu/vendeli/tgbot/types/media/PhotoSize;ILjava/lang/Object;)Leu/vendeli/tgbot/types/media/StickerSet;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Leu/vendeli/tgbot/types/media/PhotoSize;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerType;Ljava/util/List;Leu/vendeli/tgbot/types/media/PhotoSize;)Leu/vendeli/tgbot/types/media/StickerSet;
+	public static synthetic fun copy$default (Leu/vendeli/tgbot/types/media/StickerSet;Ljava/lang/String;Ljava/lang/String;Leu/vendeli/tgbot/types/media/StickerType;Ljava/util/List;Leu/vendeli/tgbot/types/media/PhotoSize;ILjava/lang/Object;)Leu/vendeli/tgbot/types/media/StickerSet;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getStickerType ()Leu/vendeli/tgbot/types/media/StickerType;
@@ -10409,8 +10864,6 @@ public final class eu/vendeli/tgbot/types/media/StickerSet {
 	public final fun getThumbnail ()Leu/vendeli/tgbot/types/media/PhotoSize;
 	public final fun getTitle ()Ljava/lang/String;
 	public fun hashCode ()I
-	public final fun isAnimated ()Z
-	public final fun isVideo ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -11447,6 +11900,7 @@ public abstract class eu/vendeli/tgbot/utils/Logger : io/ktor/client/plugins/log
 	public abstract fun debug (Lkotlin/jvm/functions/Function0;)Lkotlin/Unit;
 	public abstract fun error (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)Lkotlin/Unit;
 	public static synthetic fun error$default (Leu/vendeli/tgbot/utils/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lkotlin/Unit;
+	public final fun getId ()Ljava/lang/String;
 	public abstract fun info (Lkotlin/jvm/functions/Function0;)Lkotlin/Unit;
 	public fun log (Ljava/lang/String;)V
 	public abstract fun setLevel (Leu/vendeli/tgbot/types/internal/LogLvl;)V

--- a/telegram-bot/build.gradle.kts
+++ b/telegram-bot/build.gradle.kts
@@ -36,7 +36,6 @@ kotlin {
                 implementation(libs.stately)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.client.logging)
-                implementation(libs.logging)
 
                 api(libs.coroutines.core)
             }
@@ -44,7 +43,7 @@ kotlin {
         named("jvmTest") {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.8.0")
-                implementation("ch.qos.logback:logback-classic:1.5.3")
+                implementation(libs.logback)
 
                 implementation(libs.test.kotest.junit5)
                 implementation(libs.test.kotest.assertions)
@@ -53,21 +52,25 @@ kotlin {
         }
         named("jvmMain") {
             dependencies {
+                implementation(libs.logback)
                 implementation(libs.ktor.client.java)
             }
         }
         named("jsMain") {
             dependencies {
+                implementation(libs.logging)
                 implementation(libs.ktor.client.js)
             }
         }
         named("linuxX64Main") {
             dependencies {
+                implementation(libs.logging)
                 implementation(libs.ktor.client.curl)
             }
         }
         named("mingwX64Main") {
             dependencies {
+                implementation(libs.logging)
                 implementation(libs.ktor.client.winhttp)
             }
         }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/TelegramBot.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/TelegramBot.kt
@@ -106,5 +106,5 @@ class TelegramBot(
         }
     }
 
-    internal companion object : Logging()
+    internal companion object : Logging("TgUpdateHandler")
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/TelegramBot.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/TelegramBot.kt
@@ -106,5 +106,5 @@ class TelegramBot(
         }
     }
 
-    internal companion object : Logging("TgUpdateHandler")
+    internal companion object : Logging()
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Contact.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Contact.kt
@@ -3,6 +3,7 @@
 package eu.vendeli.tgbot.api
 
 import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
 import eu.vendeli.tgbot.types.Message
@@ -15,6 +16,7 @@ class SendContactAction(
     phoneNumber: String,
     firstName: String,
 ) : Action<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendContactAction, ContactOptions>,
     MarkupFeature<SendContactAction> {
     override val method = TgMethod("sendContact")

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Contact.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Contact.kt
@@ -31,7 +31,9 @@ class SendContactAction(
 
 /**
  * Use this method to send phone contacts. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendcontact
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param phoneNumber Contact's phone number
@@ -41,9 +43,9 @@ class SendContactAction(
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun contact(firstName: String, phoneNumber: String) = SendContactAction(phoneNumber, firstName)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Dice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Dice.kt
@@ -28,16 +28,18 @@ class SendDiceAction(emoji: String? = null) :
 
 /**
  * Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#senddice
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of "🎲", "🎯", "🏀", "⚽", "🎳", or "🎰". Dice can have values 1-6 for "🎲", "🎯" and "🎳", values 1-5 for "🏀" and "⚽", and values 1-64 for "🎰". Defaults to "🎲"
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun sendDice(emoji: String? = null) = dice(emoji)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Dice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Dice.kt
@@ -3,6 +3,7 @@
 package eu.vendeli.tgbot.api
 
 import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
 import eu.vendeli.tgbot.types.Message
@@ -13,6 +14,7 @@ import eu.vendeli.tgbot.utils.toJsonElement
 
 class SendDiceAction(emoji: String? = null) :
     Action<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendDiceAction, DiceOptions>,
     MarkupFeature<SendDiceAction> {
     override val method = TgMethod("sendDice")

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Game.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Game.kt
@@ -29,16 +29,18 @@ class SendGameAction(
 
 /**
  * Use this method to send a game. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendgame
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param gameShortName Short name of the game, serves as the unique identifier for the game. Set up your games via @BotFather.
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game.
+ * @param replyMarkup A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game. Not supported for messages sent on behalf of a business account.
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun sendGame(gameShortName: String) = game(gameShortName)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Game.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Game.kt
@@ -3,6 +3,7 @@
 package eu.vendeli.tgbot.api
 
 import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
 import eu.vendeli.tgbot.types.Message
@@ -14,6 +15,7 @@ import eu.vendeli.tgbot.utils.toJsonElement
 class SendGameAction(
     gameShortName: String,
 ) : Action<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendGameAction, GameOptions>,
     MarkupFeature<SendGameAction> {
     override val method = TgMethod("sendGame")

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetFile.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetFile.kt
@@ -20,9 +20,10 @@ class GetFileAction(fileId: String) : SimpleAction<File>() {
 /**
  * Use this method to get basic information about a file and prepare it for downloading. For the moment, bots can download files of up to 20MB in size. On success, a File object is returned. The file can then be downloaded via the link https://api.telegram.org/file/bot<token>/<file_path>, where <file_path> is taken from the response. It is guaranteed that the link will be valid for at least 1 hour. When the link expires, a new one can be requested by calling getFile again.
  * Note: This function may not preserve the original file name and MIME type. You should save the file's MIME type and name (if available) when the File object is received.
+ *
  * Api reference: https://core.telegram.org/bots/api#getfile
  * @param fileId File identifier to get information about
  * @returns [File]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getFile(fileId: String) = GetFileAction(fileId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetGameHighScores.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetGameHighScores.kt
@@ -28,13 +28,14 @@ class GetGameHighScoresAction : Action<List<GameHighScore>> {
 
 /**
  * Use this method to get data for high score tables. Will return the score of the specified user and several of their neighbors in a game. Returns an Array of GameHighScore objects.
+ *
  * Api reference: https://core.telegram.org/bots/api#getgamehighscores
  * @param userId Target user id
  * @param chatId Required if inline_message_id is not specified. Unique identifier for the target chat
  * @param messageId Required if inline_message_id is not specified. Identifier of the sent message
  * @param inlineMessageId Required if chat_id and message_id are not specified. Identifier of the inline message
  * @returns [Array of GameHighScore]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getGameHighScores(userId: Long, messageId: Long) =
     GetGameHighScoresAction(Identifier.from(userId), messageId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetGameHighScores.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetGameHighScores.kt
@@ -2,7 +2,7 @@
 
 package eu.vendeli.tgbot.api
 
-import eu.vendeli.tgbot.interfaces.InlinableAction
+import eu.vendeli.tgbot.interfaces.Action
 import eu.vendeli.tgbot.types.User
 import eu.vendeli.tgbot.types.game.GameHighScore
 import eu.vendeli.tgbot.types.internal.Identifier
@@ -12,7 +12,7 @@ import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.serde.DynamicLookupSerializer
 import eu.vendeli.tgbot.utils.toJsonElement
 
-class GetGameHighScoresAction : InlinableAction<List<GameHighScore>> {
+class GetGameHighScoresAction : Action<List<GameHighScore>> {
     override val method = TgMethod("getGameHighScores")
     override val returnType = getReturnType()
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetUserChatBoosts.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetUserChatBoosts.kt
@@ -22,11 +22,12 @@ class GetUserChatBoostsAction(
 
 /**
  * Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat. Returns a UserChatBoosts object.
+ *
  * Api reference: https://core.telegram.org/bots/api#getuserchatboosts
  * @param chatId Unique identifier for the chat or username of the channel (in the format @channelusername)
  * @param userId Unique identifier of the target user
  * @returns [UserChatBoosts]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getUserChatBoosts(userId: Long) = GetUserChatBoostsAction(userId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetUserProfilePhotos.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/GetUserProfilePhotos.kt
@@ -26,12 +26,13 @@ class GetUserProfilePhotosAction(
 
 /**
  * Use this method to get a list of profile pictures for a user. Returns a UserProfilePhotos object.
+ *
  * Api reference: https://core.telegram.org/bots/api#getuserprofilephotos
  * @param userId Unique identifier of the target user
  * @param offset Sequential number of the first photo to be returned. By default, all photos are returned.
  * @param limit Limits the number of photos to be retrieved. Values between 1-100 are accepted. Defaults to 100.
  * @returns [UserProfilePhotos]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getUserProfilePhotos(userId: Long, offset: Int? = null, limit: Int? = null) =
     GetUserProfilePhotosAction(userId, offset, limit)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Invoice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Invoice.kt
@@ -40,6 +40,7 @@ class SendInvoiceAction(
 
 /**
  * Use this method to send invoices. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendinvoice
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
@@ -69,7 +70,7 @@ class SendInvoiceAction(
  * @param replyParameters Description of the message to reply to
  * @param replyMarkup A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun invoice(
     title: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Location.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Location.kt
@@ -31,7 +31,9 @@ class SendLocationAction(
 
 /**
  * Use this method to send point on the map. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendlocation
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param latitude Latitude of the location
@@ -43,9 +45,9 @@ class SendLocationAction(
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun sendLocation(latitude: Float, longitude: Float) = location(latitude, longitude)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Location.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Location.kt
@@ -3,6 +3,7 @@
 package eu.vendeli.tgbot.api
 
 import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
 import eu.vendeli.tgbot.types.Message
@@ -15,6 +16,7 @@ class SendLocationAction(
     latitude: Float,
     longitude: Float,
 ) : Action<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendLocationAction, LocationOptions>,
     MarkupFeature<SendLocationAction> {
     override val method = TgMethod("sendLocation")

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Poll.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Poll.kt
@@ -30,7 +30,9 @@ class SendPollAction(question: String, pollOptions: List<String>) :
 
 /**
  * Use this method to send a native poll. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendpoll
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param question Poll question, 1-300 characters
@@ -48,9 +50,9 @@ class SendPollAction(question: String, pollOptions: List<String>) :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun poll(question: String, options: List<String>) = SendPollAction(question, options)
 fun poll(question: String, options: ListingBuilder<String>.() -> Unit) = poll(question, ListingBuilder.build(options))

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/SetGameScore.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/SetGameScore.kt
@@ -2,7 +2,8 @@
 
 package eu.vendeli.tgbot.api
 
-import eu.vendeli.tgbot.interfaces.InlinableAction
+import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.InlineActionExt
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
 import eu.vendeli.tgbot.types.Message
 import eu.vendeli.tgbot.types.User
@@ -12,7 +13,8 @@ import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toJsonElement
 
 class SetGameScoreAction :
-    InlinableAction<Message>,
+    Action<Message>,
+    InlineActionExt<Message>,
     OptionsFeature<SetGameScoreAction, SetGameScoreOptions> {
     override val method = TgMethod("setGameScore")
     override val returnType = getReturnType()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/SetGameScore.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/SetGameScore.kt
@@ -34,6 +34,7 @@ class SetGameScoreAction :
 
 /**
  * Use this method to set the score of the specified user in a game message. On success, if the message is not an inline message, the Message is returned, otherwise True is returned. Returns an error, if the new score is not greater than the user's current score in the chat and force is False.
+ *
  * Api reference: https://core.telegram.org/bots/api#setgamescore
  * @param userId User identifier
  * @param score New score, must be non-negative
@@ -43,7 +44,7 @@ class SetGameScoreAction :
  * @param messageId Required if inline_message_id is not specified. Identifier of the sent message
  * @param inlineMessageId Required if chat_id and message_id are not specified. Identifier of the inline message
  * @returns [Message]|[Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setGameScore(userId: Long, messageId: Long, score: Long) = SetGameScoreAction(userId, messageId, score)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/SetMessageReaction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/SetMessageReaction.kt
@@ -29,13 +29,14 @@ class SetMessageReactionAction(
 
 /**
  * Use this method to change the chosen reactions on a message. Service messages can't be reacted to. Automatically forwarded messages from a channel to its discussion group have the same available reactions as messages in the channel. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setmessagereaction
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Identifier of the target message. If the message belongs to a media group, the reaction is set to the first non-deleted message in the group instead.
- * @param reaction New list of reaction types to set on the message. Currently, as non-premium users, bots can set up to one reaction per message. A custom emoji reaction can be used if it is either already present on the message or explicitly allowed by chat administrators.
+ * @param reaction A JSON-serialized list of reaction types to set on the message. Currently, as non-premium users, bots can set up to one reaction per message. A custom emoji reaction can be used if it is either already present on the message or explicitly allowed by chat administrators.
  * @param isBig Pass True to set the reaction with a big animation
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setMessageReaction(messageId: Long, reaction: List<ReactionType>? = null, isBig: Boolean? = null) =
     SetMessageReactionAction(messageId, reaction, isBig)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/StopMessageLiveLocation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/StopMessageLiveLocation.kt
@@ -24,13 +24,14 @@ class StopMessageLiveLocationAction() :
 
 /**
  * Use this method to stop updating a live location message before live_period expires. On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#stopmessagelivelocation
  * @param chatId Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Required if inline_message_id is not specified. Identifier of the message with live location to stop
  * @param inlineMessageId Required if chat_id and message_id are not specified. Identifier of the inline message
  * @param replyMarkup A JSON-serialized object for a new inline keyboard.
  * @returns [Message]|[Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun stopMessageLiveLocation(messageId: Long) = StopMessageLiveLocationAction(messageId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/StopMessageLiveLocation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/StopMessageLiveLocation.kt
@@ -2,7 +2,8 @@
 
 package eu.vendeli.tgbot.api
 
-import eu.vendeli.tgbot.interfaces.InlinableAction
+import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.InlineActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.types.Message
 import eu.vendeli.tgbot.types.internal.TgMethod
@@ -10,7 +11,8 @@ import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toJsonElement
 
 class StopMessageLiveLocationAction() :
-    InlinableAction<Message>(),
+    Action<Message>(),
+    InlineActionExt<Message>,
     MarkupFeature<StopMessageLiveLocationAction> {
     override val method = TgMethod("stopMessageLiveLocation")
     override val returnType = getReturnType()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/StopPoll.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/StopPoll.kt
@@ -21,11 +21,12 @@ class StopPollAction(messageId: Long) : Action<Poll>(), BusinessActionExt<Poll>,
 
 /**
  * Use this method to stop a poll which was sent by the bot. On success, the stopped Poll is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#stoppoll
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Identifier of the original message with the poll
  * @param replyMarkup A JSON-serialized object for a new message inline keyboard.
  * @returns [Poll]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun stopPoll(messageId: Long) = StopPollAction(messageId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/StopPoll.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/StopPoll.kt
@@ -3,13 +3,14 @@
 package eu.vendeli.tgbot.api
 
 import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.types.Poll
 import eu.vendeli.tgbot.types.internal.TgMethod
 import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toJsonElement
 
-class StopPollAction(messageId: Long) : Action<Poll>(), MarkupFeature<SendPollAction> {
+class StopPollAction(messageId: Long) : Action<Poll>(), BusinessActionExt<Poll>, MarkupFeature<SendPollAction> {
     override val method = TgMethod("stopPoll")
     override val returnType = getReturnType()
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Venue.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/Venue.kt
@@ -33,7 +33,9 @@ class SendVenueAction(
 
 /**
  * Use this method to send information about a venue. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendvenue
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param latitude Latitude of the venue
@@ -47,9 +49,9 @@ class SendVenueAction(
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun venue(latitude: Float, longitude: Float, title: String, address: String) =
     SendVenueAction(latitude, longitude, title, address)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerCallbackQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerCallbackQuery.kt
@@ -23,6 +23,7 @@ class AnswerCallbackQueryAction(callbackQueryId: String) :
 
 /**
  * Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the user as a notification at the top of the chat screen or as an alert. On success, True is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#answercallbackquery
  * @param callbackQueryId Unique identifier for the query to be answered
  * @param text Text of the notification. If not specified, nothing will be shown to the user, 0-200 characters
@@ -30,6 +31,6 @@ class AnswerCallbackQueryAction(callbackQueryId: String) :
  * @param url URL that will be opened by the user's client. If you have created a Game and accepted the conditions via @BotFather, specify the URL that opens your game - note that this will only work if the query comes from a callback_game button. Otherwise, you may use links like t.me/your_bot?start=XXXX that open your bot with a parameter.
  * @param cacheTime The maximum amount of time in seconds that the result of the callback query may be cached client-side. Telegram apps will support caching starting in version 3.14. Defaults to 0.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun answerCallbackQuery(callbackQueryId: String) = AnswerCallbackQueryAction(callbackQueryId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerInlineQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerInlineQuery.kt
@@ -30,6 +30,7 @@ class AnswerInlineQueryAction(inlineQueryId: String, results: List<InlineQueryRe
 /**
  * Use this method to send answers to an inline query. On success, True is returned.
  * No more than 50 results per query are allowed.
+ *
  * Api reference: https://core.telegram.org/bots/api#answerinlinequery
  * @param inlineQueryId Unique identifier for the answered query
  * @param results A JSON-serialized array of results for the inline query
@@ -38,7 +39,7 @@ class AnswerInlineQueryAction(inlineQueryId: String, results: List<InlineQueryRe
  * @param nextOffset Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don't support pagination. Offset length can't exceed 64 bytes.
  * @param button A JSON-serialized object describing a button to be shown above inline query results
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun answerInlineQuery(inlineQueryId: String, results: List<InlineQueryResult>) =
     AnswerInlineQueryAction(inlineQueryId, results)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerPreCheckoutQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerPreCheckoutQuery.kt
@@ -24,12 +24,13 @@ class AnswerPreCheckoutQueryAction(
 
 /**
  * Once the user has confirmed their payment and shipping details, the Bot API sends the final confirmation in the form of an Update with the field pre_checkout_query. Use this method to respond to such pre-checkout queries. On success, True is returned. Note: The Bot API must receive an answer within 10 seconds after the pre-checkout query was sent.
+ *
  * Api reference: https://core.telegram.org/bots/api#answerprecheckoutquery
  * @param preCheckoutQueryId Unique identifier for the query to be answered
  * @param ok Specify True if everything is alright (goods are available, etc.) and the bot is ready to proceed with the order. Use False if there are any problems.
  * @param errorMessage Required if ok is False. Error message in human readable form that explains the reason for failure to proceed with the checkout (e.g. "Sorry, somebody just bought the last of our amazing black T-shirts while you were busy filling out your payment details. Please choose a different color or garment!"). Telegram will display this message to the user.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun answerPreCheckoutQuery(preCheckoutQueryId: String, ok: Boolean = true, errorMessage: String? = null) =
     AnswerPreCheckoutQueryAction(preCheckoutQueryId, ok, errorMessage)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerShippingQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerShippingQuery.kt
@@ -30,13 +30,14 @@ class AnswerShippingQueryAction(
 
 /**
  * If you sent an invoice requesting a shipping address and the parameter is_flexible was specified, the Bot API will send an Update with a shipping_query field to the bot. Use this method to reply to shipping queries. On success, True is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#answershippingquery
  * @param shippingQueryId Unique identifier for the query to be answered
  * @param ok Pass True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible)
  * @param shippingOptions Required if ok is True. A JSON-serialized array of available shipping options.
  * @param errorMessage Required if ok is False. Error message in human readable form that explains why it is impossible to complete the order (e.g. "Sorry, delivery to your desired address is unavailable'). Telegram will display this message to the user.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun answerShippingQuery(
     shippingQueryId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerWebAppQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/answer/AnswerWebAppQuery.kt
@@ -26,11 +26,12 @@ class AnswerWebAppQueryAction(
 
 /**
  * Use this method to set the result of an interaction with a Web App and send a corresponding message on behalf of the user to the chat from which the query originated. On success, a SentWebAppMessage object is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#answerwebappquery
  * @param webAppQueryId Unique identifier for the query to be answered
  * @param result A JSON-serialized object describing the message to be sent
  * @returns [SentWebAppMessage]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun answerWebAppQuery(
     webAppQueryId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/Close.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/Close.kt
@@ -13,9 +13,10 @@ class CloseAction : SimpleAction<Boolean>() {
 
 /**
  * Use this method to close the bot instance before moving it from one local server to another. You need to delete the webhook before calling this method to ensure that the bot isn't launched again after server restart. The method will return error 429 in the first 10 minutes after the bot is launched. Returns True on success. Requires no parameters.
+ *
  * Api reference: https://core.telegram.org/bots/api#close
  *
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun close() = CloseAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/CreateInvoiceLink.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/CreateInvoiceLink.kt
@@ -36,6 +36,7 @@ class CreateInvoiceLinkAction(
 
 /**
  * Use this method to create a link for an invoice. Returns the created invoice link as String on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#createinvoicelink
  * @param title Product name, 1-32 characters
  * @param description Product description, 1-255 characters
@@ -58,7 +59,7 @@ class CreateInvoiceLinkAction(
  * @param sendEmailToProvider Pass True if the user's email address should be sent to the provider
  * @param isFlexible Pass True if the final price depends on the shipping method
  * @returns [String]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun createInvoiceLink(
     title: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/DeleteMyCommands.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/DeleteMyCommands.kt
@@ -24,11 +24,12 @@ class DeleteMyCommandsAction(
 
 /**
  * Use this method to delete the list of the bot's commands for the given scope and user language. After deletion, higher level commands will be shown to affected users. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deletemycommands
  * @param scope A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
  * @param languageCode A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteMyCommands(languageCode: String? = null, scope: BotCommandScope? = null) =
     DeleteMyCommandsAction(scope, languageCode)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/DeleteWebhook.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/DeleteWebhook.kt
@@ -18,9 +18,10 @@ class DeleteWebhookAction(dropPendingUpdates: Boolean = false) : SimpleAction<Bo
 
 /**
  * Use this method to remove webhook integration if you decide to switch back to getUpdates. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deletewebhook
  * @param dropPendingUpdates Pass True to drop all pending updates
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteWebhook(dropPendingUpdates: Boolean = false) = DeleteWebhookAction(dropPendingUpdates)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetBusinessConnection.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetBusinessConnection.kt
@@ -18,5 +18,12 @@ class GetBusinessConnectionAction(businessConnectionId: String) :
     }
 }
 
+/**
+ * Use this method to get information about the connection of the bot with a business account. Returns a BusinessConnection object on success.
+ *
+ * Api reference: https://core.telegram.org/bots/api#getbusinessconnection
+ * @param businessConnectionId Unique identifier of the business connection
+ * @returns [BusinessConnection]
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getBusinessConnection(businessConnectionId: String) = GetBusinessConnectionAction(businessConnectionId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetBusinessConnection.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetBusinessConnection.kt
@@ -1,0 +1,22 @@
+@file:Suppress("MatchingDeclarationName")
+
+package eu.vendeli.tgbot.api.botactions
+
+import eu.vendeli.tgbot.interfaces.SimpleAction
+import eu.vendeli.tgbot.types.business.BusinessConnection
+import eu.vendeli.tgbot.types.internal.TgMethod
+import eu.vendeli.tgbot.utils.getReturnType
+import eu.vendeli.tgbot.utils.toJsonElement
+
+class GetBusinessConnectionAction(businessConnectionId: String) :
+    SimpleAction<BusinessConnection>() {
+    override val method = TgMethod("getBusinessConnection")
+    override val returnType = getReturnType()
+
+    init {
+        parameters["business_connection_id"] = businessConnectionId.toJsonElement()
+    }
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun getBusinessConnection(businessConnectionId: String) = GetBusinessConnectionAction(businessConnectionId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMe.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMe.kt
@@ -14,9 +14,10 @@ class GetMeAction : SimpleAction<User>() {
 
 /**
  * A simple method for testing your bot's authentication token. Requires no parameters. Returns basic information about the bot in form of a User object.
+ *
  * Api reference: https://core.telegram.org/bots/api#getme
  *
  * @returns [User]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getMe() = GetMeAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyCommands.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyCommands.kt
@@ -25,11 +25,12 @@ class GetMyCommandsAction(
 
 /**
  * Use this method to get the current list of the bot's commands for the given scope and user language. Returns an Array of BotCommand objects. If commands aren't set, an empty list is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#getmycommands
  * @param scope A JSON-serialized object, describing scope of users. Defaults to BotCommandScopeDefault.
  * @param languageCode A two-letter ISO 639-1 language code or an empty string
  * @returns [Array of BotCommand]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getMyCommands(languageCode: String? = null, scope: BotCommandScope? = null) =
     GetMyCommandsAction(scope, languageCode)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyDefaultAdministratorRights.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyDefaultAdministratorRights.kt
@@ -20,10 +20,11 @@ class GetMyDefaultAdministratorRightsAction(forChannel: Boolean? = null) :
 
 /**
  * Use this method to get the current default administrator rights of the bot. Returns ChatAdministratorRights on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#getmydefaultadministratorrights
  * @param forChannels Pass True to get default administrator rights of the bot in channels. Otherwise, default administrator rights of the bot for groups and supergroups will be returned.
  * @returns [ChatAdministratorRights]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getMyDefaultAdministratorRights(forChannel: Boolean? = null) =
     GetMyDefaultAdministratorRightsAction(forChannel)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyDescription.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyDescription.kt
@@ -19,9 +19,10 @@ class GetMyDescriptionAction(languageCode: String? = null) : SimpleAction<BotDes
 
 /**
  * Use this method to get the current bot description for the given user language. Returns BotDescription on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#getmydescription
  * @param languageCode A two-letter ISO 639-1 language code or an empty string
  * @returns [BotDescription]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getMyDescription(languageCode: String? = null) = GetMyDescriptionAction(languageCode)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyName.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyName.kt
@@ -19,9 +19,10 @@ class GetMyNameAction(languageCode: String? = null) : SimpleAction<BotName>() {
 
 /**
  * Use this method to get the current bot name for the given user language. Returns BotName on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#getmyname
  * @param languageCode A two-letter ISO 639-1 language code or an empty string
  * @returns [BotName]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getMyName(languageCode: String? = null) = GetMyNameAction(languageCode)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyShortDescription.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetMyShortDescription.kt
@@ -19,9 +19,10 @@ class GetMyShortDescriptionAction(languageCode: String? = null) : SimpleAction<B
 
 /**
  * Use this method to get the current bot short description for the given user language. Returns BotShortDescription on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#getmyshortdescription
  * @param languageCode A two-letter ISO 639-1 language code or an empty string
  * @returns [BotShortDescription]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getMyShortDescription(languageCode: String? = null) = GetMyShortDescriptionAction(languageCode)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetUpdates.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetUpdates.kt
@@ -19,12 +19,13 @@ class GetUpdatesAction :
 
 /**
  * Use this method to receive incoming updates using long polling (wiki). Returns an Array of Update objects.
+ *
  * Api reference: https://core.telegram.org/bots/api#getupdates
  * @param offset Identifier of the first update to be returned. Must be greater by one than the highest among the identifiers of previously received updates. By default, updates starting with the earliest unconfirmed update are returned. An update is considered confirmed as soon as getUpdates is called with an offset higher than its update_id. The negative offset can be specified to retrieve updates starting from -offset update from the end of the updates queue. All previous updates will be forgotten.
  * @param limit Limits the number of updates to be retrieved. Values between 1-100 are accepted. Defaults to 100.
  * @param timeout Timeout in seconds for long polling. Defaults to 0, i.e. usual short polling. Should be positive, short polling should be used for testing purposes only.
  * @param allowedUpdates A JSON-serialized list of the update types you want your bot to receive. For example, specify ["message", "edited_channel_post", "callback_query"] to only receive updates of these types. See Update for a complete list of available update types. Specify an empty list to receive all update types except chat_member, message_reaction, and message_reaction_count (default). If not specified, the previous setting will be used. Please note that this parameter doesn't affect updates created before the call to the getUpdates, so unwanted updates may be received for a short period of time.
  * @returns [Array of Update]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getUpdates() = GetUpdatesAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetWebhookInfo.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/GetWebhookInfo.kt
@@ -14,9 +14,10 @@ class GetWebhookInfoAction : SimpleAction<WebhookInfo>() {
 
 /**
  * Use this method to get current webhook status. Requires no parameters. On success, returns a WebhookInfo object. If the bot is using getUpdates, will return an object with the url field empty.
+ *
  * Api reference: https://core.telegram.org/bots/api#getwebhookinfo
  *
  * @returns [WebhookInfo]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getWebhookInfo() = GetWebhookInfoAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/Logout.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/Logout.kt
@@ -13,9 +13,10 @@ class LogOutAction : SimpleAction<Boolean>() {
 
 /**
  * Use this method to log out from the cloud Bot API server before launching the bot locally. You must log out the bot before running it locally, otherwise there is no guarantee that the bot will receive updates. After a successful call, you can immediately log in on a local server, but will not be able to log in back to the cloud Bot API server for 10 minutes. Returns True on success. Requires no parameters.
+ *
  * Api reference: https://core.telegram.org/bots/api#logout
  *
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun logOut() = LogOutAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyCommands.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyCommands.kt
@@ -28,12 +28,13 @@ class SetMyCommandsAction(
 
 /**
  * Use this method to change the list of the bot's commands. See this manual for more details about bot commands. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setmycommands
  * @param commands A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
  * @param scope A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
  * @param languageCode A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setMyCommands(languageCode: String? = null, scope: BotCommandScope? = null, command: List<BotCommand>) =
     SetMyCommandsAction(languageCode, scope, command)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyDefaultAdministratorRights.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyDefaultAdministratorRights.kt
@@ -24,11 +24,12 @@ class SetMyDefaultAdministratorRightsAction(
 
 /**
  * Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels. These rights will be suggested to users, but they are free to modify the list before adding the bot. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setmydefaultadministratorrights
  * @param rights A JSON-serialized object describing new default administrator rights. If not specified, the default administrator rights will be cleared.
  * @param forChannels Pass True to change the default administrator rights of the bot in channels. Otherwise, the default administrator rights of the bot for groups and supergroups will be changed.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setMyDefaultAdministratorRights(rights: ChatAdministratorRights? = null, forChannel: Boolean? = null) =
     SetMyDefaultAdministratorRightsAction(rights, forChannel)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyDescription.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyDescription.kt
@@ -22,11 +22,12 @@ class SetMyDescriptionAction(
 
 /**
  * Use this method to change the bot's description, which is shown in the chat with the bot if the chat is empty. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setmydescription
  * @param description New bot description; 0-512 characters. Pass an empty string to remove the dedicated description for the given language.
  * @param languageCode A two-letter ISO 639-1 language code. If empty, the description will be applied to all users for whose language there is no dedicated description.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setMyDescription(
     description: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyName.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyName.kt
@@ -19,10 +19,11 @@ class SetMyNameAction(name: String? = null, languageCode: String? = null) : Simp
 
 /**
  * Use this method to change the bot's name. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setmyname
  * @param name New bot name; 0-64 characters. Pass an empty string to remove the dedicated name for the given language.
  * @param languageCode A two-letter ISO 639-1 language code. If empty, the name will be shown to all users for whose language there is no dedicated name.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setMyName(name: String? = null, languageCode: String? = null) = SetMyNameAction(name, languageCode)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyShortDescription.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/botactions/SetMyShortDescription.kt
@@ -22,11 +22,12 @@ class SetMyShortDescriptionAction(
 
 /**
  * Use this method to change the bot's short description, which is shown on the bot's profile page and is sent together with the link when users share the bot. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setmyshortdescription
  * @param shortDescription New short description for the bot; 0-120 characters. Pass an empty string to remove the dedicated short description for the given language.
  * @param languageCode A two-letter ISO 639-1 language code. If empty, the short description will be applied to all users for whose language there is no dedicated short description.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setMyShortDescription(
     description: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/ApproveChatJoinRequest.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/ApproveChatJoinRequest.kt
@@ -19,11 +19,12 @@ class ApproveChatJoinRequestAction(userId: Long) : Action<Boolean>() {
 
 /**
  * Use this method to approve a chat join request. The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#approvechatjoinrequest
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param userId Unique identifier of the target user
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun approveChatJoinRequest(userId: Long) = ApproveChatJoinRequestAction(userId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/BanChatMember.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/BanChatMember.kt
@@ -26,13 +26,14 @@ class BanChatMemberAction(
 
 /**
  * Use this method to ban a user in a group, a supergroup or a channel. In the case of supergroups and channels, the user will not be able to return to the chat on their own using invite links, etc., unless unbanned first. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#banchatmember
  * @param chatId Unique identifier for the target group or username of the target supergroup or channel (in the format @channelusername)
  * @param userId Unique identifier of the target user
  * @param untilDate Date when the user will be unbanned; Unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever. Applied for supergroups and channels only.
  * @param revokeMessages Pass True to delete all messages from the chat for the user that is being removed. If False, the user will be able to see messages in the group that were sent before the user was removed. Always True for supergroups and channels.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun banChatMember(userId: Long, untilDate: Instant? = null, revokeMessages: Boolean? = null) =
     BanChatMemberAction(userId, untilDate, revokeMessages)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/BanChatSenderChat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/BanChatSenderChat.kt
@@ -20,11 +20,12 @@ class BanChatSenderChatAction(senderChatId: Long) : Action<Boolean>() {
 
 /**
  * Use this method to ban a channel chat in a supergroup or a channel. Until the chat is unbanned, the owner of the banned chat won't be able to send messages on behalf of any of their channels. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#banchatsenderchat
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param senderChatId Unique identifier of the target sender chat
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun banChatSenderChat(senderChatId: Long) = BanChatSenderChatAction(senderChatId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/ChatAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/ChatAction.kt
@@ -23,12 +23,14 @@ class SendChatAction(action: ChatAction, messageThreadId: Int? = null) : Action<
 /**
  * Use this method when you need to tell the user that something is happening on the bot's side. The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status). Returns True on success.
  * We only recommend using this method when a response from the bot will take a noticeable amount of time to arrive.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendchataction
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the action will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @param messageThreadId Unique identifier for the target message thread; supergroups only
+ * @param messageThreadId Unique identifier for the target message thread; for supergroups only
  * @param action Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun chatAction(action: ChatAction, messageThreadId: Int? = null) = SendChatAction(action, messageThreadId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/ChatAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/ChatAction.kt
@@ -3,13 +3,14 @@
 package eu.vendeli.tgbot.api.chat
 
 import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.types.chat.ChatAction
 import eu.vendeli.tgbot.types.internal.TgMethod
 import eu.vendeli.tgbot.utils.encodeWith
 import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toJsonElement
 
-class SendChatAction(action: ChatAction, messageThreadId: Int? = null) : Action<Boolean>() {
+class SendChatAction(action: ChatAction, messageThreadId: Int? = null) : Action<Boolean>(), BusinessActionExt<Boolean> {
     override val method = TgMethod("sendChatAction")
     override val returnType = getReturnType()
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/CreateChatInviteLink.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/CreateChatInviteLink.kt
@@ -19,6 +19,7 @@ class CreateChatInviteLinkAction :
 
 /**
  * Use this method to create an additional invite link for a chat. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. The link can be revoked using the method revokeChatInviteLink. Returns the new invite link as ChatInviteLink object.
+ *
  * Api reference: https://core.telegram.org/bots/api#createchatinvitelink
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param name Invite link name; 0-32 characters
@@ -26,6 +27,6 @@ class CreateChatInviteLinkAction :
  * @param memberLimit The maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
  * @param createsJoinRequest True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
  * @returns [ChatInviteLink]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun createChatInviteLink() = CreateChatInviteLinkAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/DeclineChatJoinRequest.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/DeclineChatJoinRequest.kt
@@ -19,11 +19,12 @@ class DeclineChatJoinRequestAction(userId: Long) : Action<Boolean>() {
 
 /**
  * Use this method to decline a chat join request. The bot must be an administrator in the chat for this to work and must have the can_invite_users administrator right. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#declinechatjoinrequest
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param userId Unique identifier of the target user
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun declineChatJoinRequest(userId: Long) = DeclineChatJoinRequestAction(userId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/DeleteChatPhoto.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/DeleteChatPhoto.kt
@@ -13,9 +13,10 @@ class DeleteChatPhotoAction : Action<Boolean>() {
 
 /**
  * Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deletechatphoto
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteChatPhoto() = DeleteChatPhotoAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/DeleteChatStickerSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/DeleteChatStickerSet.kt
@@ -13,9 +13,10 @@ class DeleteChatStickerSetAction : Action<Boolean>() {
 
 /**
  * Use this method to delete a group sticker set from a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Use the field can_set_sticker_set optionally returned in getChat requests to check if the bot can use this method. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deletechatstickerset
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteChatStickerSet() = DeleteChatStickerSetAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/EditChatInviteLink.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/EditChatInviteLink.kt
@@ -24,6 +24,7 @@ class EditChatInviteLinkAction(inviteLink: String) :
 
 /**
  * Use this method to edit a non-primary invite link created by the bot. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns the edited invite link as a ChatInviteLink object.
+ *
  * Api reference: https://core.telegram.org/bots/api#editchatinvitelink
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param inviteLink The invite link to edit
@@ -32,6 +33,6 @@ class EditChatInviteLinkAction(inviteLink: String) :
  * @param memberLimit The maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
  * @param createsJoinRequest True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
  * @returns [ChatInviteLink]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun editChatInviteLink(inviteLink: String) = EditChatInviteLinkAction(inviteLink)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/ExportChatInviteLink.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/ExportChatInviteLink.kt
@@ -13,9 +13,10 @@ class ExportChatInviteLinkAction : Action<String>() {
 
 /**
  * Use this method to generate a new primary invite link for a chat; any previously generated primary link is revoked. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns the new invite link as String on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#exportchatinvitelink
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @returns [String]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun exportChatInviteLink() = ExportChatInviteLinkAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChat.kt
@@ -14,9 +14,10 @@ class GetChatAction : Action<Chat>() {
 
 /**
  * Use this method to get up to date information about the chat. Returns a Chat object on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#getchat
  * @param chatId Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
  * @returns [Chat]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getChat() = GetChatAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChatAdministrators.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChatAdministrators.kt
@@ -14,9 +14,10 @@ class GetChatAdministratorsAction : Action<List<ChatMember>>() {
 
 /**
  * Use this method to get a list of administrators in a chat, which aren't bots. Returns an Array of ChatMember objects.
+ *
  * Api reference: https://core.telegram.org/bots/api#getchatadministrators
  * @param chatId Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
  * @returns [Array of ChatMember]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getChatAdministrators() = GetChatAdministratorsAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChatMember.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChatMember.kt
@@ -20,11 +20,12 @@ class GetChatMemberAction(userId: Long) : Action<ChatMember>() {
 
 /**
  * Use this method to get information about a member of a chat. The method is only guaranteed to work for other users if the bot is an administrator in the chat. Returns a ChatMember object on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#getchatmember
  * @param chatId Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
  * @param userId Unique identifier of the target user
  * @returns [ChatMember]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getChatMember(userId: Long) = GetChatMemberAction(userId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChatMemberCount.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChatMemberCount.kt
@@ -13,9 +13,10 @@ class GetChatMemberCountAction : Action<Int>() {
 
 /**
  * Use this method to get the number of members in a chat. Returns Int on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#getchatmembercount
  * @param chatId Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
  * @returns [Integer]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getChatMemberCount() = GetChatMemberCountAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChatMenuButton.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/GetChatMenuButton.kt
@@ -14,9 +14,10 @@ class GetChatMenuButtonAction : Action<MenuButton>() {
 
 /**
  * Use this method to get the current value of the bot's menu button in a private chat, or the default menu button. Returns MenuButton on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#getchatmenubutton
  * @param chatId Unique identifier for the target private chat. If not specified, default bot's menu button will be returned
  * @returns [MenuButton]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getChatMenuButton() = GetChatMenuButtonAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/LeaveChat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/LeaveChat.kt
@@ -13,9 +13,10 @@ class LeaveChatAction : Action<Boolean>() {
 
 /**
  * Use this method for your bot to leave a group, supergroup or channel. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#leavechat
  * @param chatId Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun leaveChat() = LeaveChatAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/PinChatMessage.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/PinChatMessage.kt
@@ -19,12 +19,13 @@ class PinChatMessageAction(messageId: Long, disableNotification: Boolean? = null
 
 /**
  * Use this method to add a message to the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' administrator right in a supergroup or 'can_edit_messages' administrator right in a channel. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#pinchatmessage
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Identifier of a message to pin
  * @param disableNotification Pass True if it is not necessary to send a notification to all chat members about the new pinned message. Notifications are always disabled in channels and private chats.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun pinChatMessage(messageId: Long, disableNotification: Boolean? = null) =
     PinChatMessageAction(messageId, disableNotification)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/PromoteChatMember.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/PromoteChatMember.kt
@@ -24,6 +24,7 @@ class PromoteChatMemberAction(userId: Long) :
 
 /**
  * Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Pass False for all boolean parameters to demote a user. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#promotechatmember
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param userId Unique identifier of the target user
@@ -38,12 +39,12 @@ class PromoteChatMemberAction(userId: Long) :
  * @param canPostStories Pass True if the administrator can post stories to the chat
  * @param canEditStories Pass True if the administrator can edit stories posted by other users
  * @param canDeleteStories Pass True if the administrator can delete stories posted by other users
- * @param canPostMessages Pass True if the administrator can post messages in the channel, or access channel statistics; channels only
- * @param canEditMessages Pass True if the administrator can edit messages of other users and can pin messages; channels only
- * @param canPinMessages Pass True if the administrator can pin messages, supergroups only
- * @param canManageTopics Pass True if the user is allowed to create, rename, close, and reopen forum topics, supergroups only
+ * @param canPostMessages Pass True if the administrator can post messages in the channel, or access channel statistics; for channels only
+ * @param canEditMessages Pass True if the administrator can edit messages of other users and can pin messages; for channels only
+ * @param canPinMessages Pass True if the administrator can pin messages; for supergroups only
+ * @param canManageTopics Pass True if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun promoteChatMember(userId: Long) = PromoteChatMemberAction(userId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/RestrictChatMember.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/RestrictChatMember.kt
@@ -31,6 +31,7 @@ class RestrictChatMemberAction(
 
 /**
  * Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate administrator rights. Pass True for all permissions to lift restrictions from a user. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#restrictchatmember
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param userId Unique identifier of the target user
@@ -38,7 +39,7 @@ class RestrictChatMemberAction(
  * @param useIndependentChatPermissions Pass True if chat permissions are set independently. Otherwise, the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages, can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes permissions; the can_send_polls permission will imply the can_send_messages permission.
  * @param untilDate Date when restrictions will be lifted for the user; Unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever
  * @returns [Boolean]
-*/
+ */
 inline fun restrictChatMember(
     userId: Long,
     untilDate: Instant? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/RevokeChatInviteLink.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/RevokeChatInviteLink.kt
@@ -19,10 +19,11 @@ class RevokeChatInviteLinkAction(inviteLink: String) : Action<ChatInviteLink>() 
 
 /**
  * Use this method to revoke an invite link created by the bot. If the primary link is revoked, a new link is automatically generated. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns the revoked invite link as ChatInviteLink object.
+ *
  * Api reference: https://core.telegram.org/bots/api#revokechatinvitelink
  * @param chatId Unique identifier of the target chat or username of the target channel (in the format @channelusername)
  * @param inviteLink The invite link to revoke
  * @returns [ChatInviteLink]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun revokeChatInviteLink(inviteLink: String) = RevokeChatInviteLinkAction(inviteLink)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatAdministratorCustomTitle.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatAdministratorCustomTitle.kt
@@ -20,12 +20,13 @@ class SetChatAdministratorCustomTitleAction(userId: Long, customTitle: String) :
 
 /**
  * Use this method to set a custom title for an administrator in a supergroup promoted by the bot. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setchatadministratorcustomtitle
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param userId Unique identifier of the target user
  * @param customTitle New custom title for the administrator; 0-16 characters, emoji are not allowed
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setChatAdministratorCustomTitle(userId: Long, customTitle: String) =
     SetChatAdministratorCustomTitleAction(userId, customTitle)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatDescription.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatDescription.kt
@@ -18,10 +18,11 @@ class SetChatDescriptionAction(description: String? = null) : Action<Boolean>() 
 
 /**
  * Use this method to change the description of a group, a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setchatdescription
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param description New chat description, 0-255 characters
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setChatDescription(title: String? = null) = SetChatDescriptionAction(title)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatMenuButton.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatMenuButton.kt
@@ -20,10 +20,11 @@ class SetChatMenuButtonAction(menuButton: MenuButton) : Action<Boolean>() {
 
 /**
  * Use this method to change the bot's menu button in a private chat, or the default menu button. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setchatmenubutton
  * @param chatId Unique identifier for the target private chat. If not specified, default bot's menu button will be changed
  * @param menuButton A JSON-serialized object for the bot's new menu button. Defaults to MenuButtonDefault
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setChatMenuButton(menuButton: MenuButton) = SetChatMenuButtonAction(menuButton)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatPermissions.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatPermissions.kt
@@ -25,12 +25,13 @@ class SetChatPermissionsAction(
 
 /**
  * Use this method to set default chat permissions for all members. The bot must be an administrator in the group or a supergroup for this to work and must have the can_restrict_members administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setchatpermissions
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param permissions A JSON-serialized object for new default chat permissions
  * @param useIndependentChatPermissions Pass True if chat permissions are set independently. Otherwise, the can_send_other_messages and can_add_web_page_previews permissions will imply the can_send_messages, can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes permissions; the can_send_polls permission will imply the can_send_messages permission.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setChatPermissions(
     permissions: ChatPermissions,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatPhoto.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatPhoto.kt
@@ -21,11 +21,12 @@ class SetChatPhotoAction(photo: ImplicitFile) : MediaAction<Boolean>() {
 
 /**
  * Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setchatphoto
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param photo New chat photo, uploaded using multipart/form-data
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setChatPhoto(file: ImplicitFile) = SetChatPhotoAction(file)
 inline fun setChatPhoto(block: () -> String) = setChatPhoto(block().toImplicitFile())

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatStickerSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatStickerSet.kt
@@ -18,10 +18,11 @@ class SetChatStickerSetAction(stickerSetName: String) : Action<Boolean>() {
 
 /**
  * Use this method to set a new group sticker set for a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Use the field can_set_sticker_set optionally returned in getChat requests to check if the bot can use this method. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setchatstickerset
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param stickerSetName Name of the sticker set to be set as the group sticker set
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setChatStickerSet(stickerSetName: String) = SetChatStickerSetAction(stickerSetName)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatTitle.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/SetChatTitle.kt
@@ -18,10 +18,11 @@ class SetChatTitleAction(title: String) : Action<Boolean>() {
 
 /**
  * Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setchattitle
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param title New chat title, 1-128 characters
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setChatTitle(title: String) = SetChatTitleAction(title)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/UnbanChatMember.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/UnbanChatMember.kt
@@ -23,12 +23,13 @@ class UnbanChatMemberAction(
 
 /**
  * Use this method to unban a previously banned user in a supergroup or channel. The user will not return to the group or channel automatically, but will be able to join via link, etc. The bot must be an administrator for this to work. By default, this method guarantees that after the call the user is not a member of the chat, but will be able to join it. So if the user is a member of the chat they will also be removed from the chat. If you don't want this, use the parameter only_if_banned. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#unbanchatmember
  * @param chatId Unique identifier for the target group or username of the target supergroup or channel (in the format @channelusername)
  * @param userId Unique identifier of the target user
  * @param onlyIfBanned Do nothing if the user is not banned
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun unbanChatMember(userId: Long, onlyIfBanned: Boolean? = null) = UnbanChatMemberAction(userId, onlyIfBanned)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/UnbanChatSenderChat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/UnbanChatSenderChat.kt
@@ -20,11 +20,12 @@ class UnbanChatSenderChatAction(senderChatId: Long) : Action<Boolean>() {
 
 /**
  * Use this method to unban a previously banned channel chat in a supergroup or channel. The bot must be an administrator for this to work and must have the appropriate administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#unbanchatsenderchat
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param senderChatId Unique identifier of the target sender chat
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun unbanChatSenderChat(senderChatId: Long) = UnbanChatSenderChatAction(senderChatId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/UnpinAllChatMessage.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/UnpinAllChatMessage.kt
@@ -13,9 +13,10 @@ class UnpinAllChatMessagesAction : Action<Boolean>() {
 
 /**
  * Use this method to clear the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' administrator right in a supergroup or 'can_edit_messages' administrator right in a channel. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#unpinallchatmessages
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun unpinAllChatMessages() = UnpinAllChatMessagesAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/UnpinChatMessage.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/chat/UnpinChatMessage.kt
@@ -18,10 +18,11 @@ class UnpinChatMessageAction(messageId: Long) : Action<Boolean>() {
 
 /**
  * Use this method to remove a message from the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' administrator right in a supergroup or 'can_edit_messages' administrator right in a channel. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#unpinchatmessage
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Identifier of a message to unpin. If not specified, the most recent pinned message (by sending date) will be unpinned.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun unpinChatMessage(messageId: Long) = UnpinChatMessageAction(messageId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/CloseForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/CloseForumTopic.kt
@@ -18,10 +18,11 @@ class CloseForumTopicAction(messageThreadId: Int) : Action<Boolean>() {
 
 /**
  * Use this method to close an open topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#closeforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param messageThreadId Unique identifier for the target message thread of the forum topic
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun closeForumTopic(messageThreadId: Int) = CloseForumTopicAction(messageThreadId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/CloseGeneralForumTopicAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/CloseGeneralForumTopicAction.kt
@@ -13,9 +13,10 @@ class CloseGeneralForumTopicAction : Action<Boolean>() {
 
 /**
  * Use this method to close an open 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#closegeneralforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun closeGeneralForumTopic() = CloseGeneralForumTopicAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/CreateForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/CreateForumTopic.kt
@@ -27,13 +27,14 @@ class CreateForumTopicAction(
 
 /**
  * Use this method to create a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns information about the created topic as a ForumTopic object.
+ *
  * Api reference: https://core.telegram.org/bots/api#createforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param name Topic name, 1-128 characters
  * @param iconColor Color of the topic icon in RGB format. Currently, must be one of 7322096 (0x6FB9F0), 16766590 (0xFFD67E), 13338331 (0xCB86DB), 9367192 (0x8EEE98), 16749490 (0xFF93B2), or 16478047 (0xFB6F5F)
  * @param iconCustomEmojiId Unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers.
  * @returns [ForumTopic]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun createForumTopic(name: String, iconColor: IconColor? = null, iconCustomEmojiId: String? = null) =
     CreateForumTopicAction(name, iconColor, iconCustomEmojiId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/DeleteForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/DeleteForumTopic.kt
@@ -18,10 +18,11 @@ class DeleteForumTopicAction(messageThreadId: Int) : Action<Boolean>() {
 
 /**
  * Use this method to delete a forum topic along with all its messages in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_delete_messages administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deleteforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param messageThreadId Unique identifier for the target message thread of the forum topic
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteForumTopic(messageThreadId: Int) = DeleteForumTopicAction(messageThreadId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/EditForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/EditForumTopic.kt
@@ -24,13 +24,14 @@ class EditForumTopicAction(
 
 /**
  * Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#editforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param messageThreadId Unique identifier for the target message thread of the forum topic
  * @param name New topic name, 0-128 characters. If not specified or empty, the current name of the topic will be kept
  * @param iconCustomEmojiId New unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers. Pass an empty string to remove the icon. If not specified, the current icon will be kept
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun editForumTopic(messageThreadId: Int, name: String? = null, iconCustomEmojiId: String? = null) =
     EditForumTopicAction(messageThreadId, name, iconCustomEmojiId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/EditGeneralForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/EditGeneralForumTopic.kt
@@ -18,10 +18,11 @@ class EditGeneralForumTopicAction(name: String) : Action<Boolean>() {
 
 /**
  * Use this method to edit the name of the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#editgeneralforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param name New topic name, 1-128 characters
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun editGeneralForumTopic(name: String) = EditGeneralForumTopicAction(name)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/GetForumTopicIconStickers.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/GetForumTopicIconStickers.kt
@@ -14,9 +14,10 @@ class GetForumTopicIconStickersAction : Action<List<Sticker>>() {
 
 /**
  * Use this method to get custom emoji stickers, which can be used as a forum topic icon by any user. Requires no parameters. Returns an Array of Sticker objects.
+ *
  * Api reference: https://core.telegram.org/bots/api#getforumtopiciconstickers
  *
  * @returns [Array of Sticker]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getForumTopicIconStickers() = GetForumTopicIconStickersAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/HideGeneralForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/HideGeneralForumTopic.kt
@@ -13,9 +13,10 @@ class HideGeneralForumTopicAction : Action<Boolean>() {
 
 /**
  * Use this method to hide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically closed if it was open. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#hidegeneralforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun hideGeneralForumTopic() = HideGeneralForumTopicAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/ReopenForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/ReopenForumTopic.kt
@@ -18,10 +18,11 @@ class ReopenForumTopicAction(messageThreadId: Int) : Action<Boolean>() {
 
 /**
  * Use this method to reopen a closed topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#reopenforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param messageThreadId Unique identifier for the target message thread of the forum topic
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun reopenForumTopic(messageThreadId: Int) = ReopenForumTopicAction(messageThreadId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/ReopenGeneralForumTopicAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/ReopenGeneralForumTopicAction.kt
@@ -13,9 +13,10 @@ class ReopenGeneralForumTopicAction : Action<Boolean>() {
 
 /**
  * Use this method to reopen a closed 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically unhidden if it was hidden. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#reopengeneralforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun reopenGeneralForumTopic() = ReopenGeneralForumTopicAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/UnhideGeneralForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/UnhideGeneralForumTopic.kt
@@ -13,9 +13,10 @@ class UnhideGeneralForumTopicAction : Action<Boolean>() {
 
 /**
  * Use this method to unhide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#unhidegeneralforumtopic
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun unhideGeneralForumTopic() = UnhideGeneralForumTopicAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/UnpinAllForumTopicMessagesAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/UnpinAllForumTopicMessagesAction.kt
@@ -18,10 +18,11 @@ class UnpinAllForumTopicMessagesAction(messageThreadId: Int) : Action<Boolean>()
 
 /**
  * Use this method to clear the list of pinned messages in a forum topic. The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#unpinallforumtopicmessages
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @param messageThreadId Unique identifier for the target message thread of the forum topic
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun unpinAllForumTopicMessages(messageThreadId: Int) = UnpinAllForumTopicMessagesAction(messageThreadId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/UnpinAllGeneralForumTopicMessagesAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/forum/UnpinAllGeneralForumTopicMessagesAction.kt
@@ -13,9 +13,10 @@ class UnpinAllGeneralForumTopicMessagesAction : Action<Boolean>() {
 
 /**
  * Use this method to clear the list of pinned messages in a General forum topic. The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#unpinallgeneralforumtopicmessages
  * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun unpinAllGeneralForumTopicMessages() = UnpinAllGeneralForumTopicMessagesAction()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Animation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Animation.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.CaptionFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
@@ -17,6 +18,7 @@ import eu.vendeli.tgbot.utils.toImplicitFile
 
 class SendAnimationAction(animation: ImplicitFile) :
     MediaAction<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendAnimationAction, AnimationOptions>,
     MarkupFeature<SendAnimationAction>,
     CaptionFeature<SendAnimationAction> {

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Animation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Animation.kt
@@ -33,7 +33,9 @@ class SendAnimationAction(animation: ImplicitFile) :
 
 /**
  * Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound). On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendanimation
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param animation Animation to send. Pass a file_id as String to send an animation that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an animation from the Internet, or upload a new animation using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files
@@ -48,9 +50,9 @@ class SendAnimationAction(animation: ImplicitFile) :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun animation(file: ImplicitFile) = SendAnimationAction(file)
 inline fun animation(block: () -> String) = animation(block().toImplicitFile())

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Audio.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Audio.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.CaptionFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
@@ -17,6 +18,7 @@ import eu.vendeli.tgbot.utils.toImplicitFile
 
 class SendAudioAction(audio: ImplicitFile) :
     MediaAction<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendAudioAction, AudioOptions>,
     MarkupFeature<SendAudioAction>,
     CaptionFeature<SendAudioAction> {

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Audio.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Audio.kt
@@ -34,7 +34,9 @@ class SendAudioAction(audio: ImplicitFile) :
 /**
  * Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
  * For sending voice messages, use the sendVoice method instead.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendaudio
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param audio Audio file to send. Pass a file_id as String to send an audio file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an audio file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files
@@ -48,9 +50,9 @@ class SendAudioAction(audio: ImplicitFile) :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun audio(file: ImplicitFile) = SendAudioAction(file)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Document.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Document.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.CaptionFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
@@ -17,6 +18,7 @@ import eu.vendeli.tgbot.utils.toImplicitFile
 
 class SendDocumentAction(document: ImplicitFile) :
     MediaAction<Message>(),
+    BusinessActionExt<Message>,
     CaptionFeature<SendDocumentAction>,
     OptionsFeature<SendDocumentAction, DocumentOptions>,
     MarkupFeature<SendDocumentAction> {

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Document.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Document.kt
@@ -33,7 +33,9 @@ class SendDocumentAction(document: ImplicitFile) :
 
 /**
  * Use this method to send general files. On success, the sent Message is returned. Bots can currently send files of any type of up to 50 MB in size, this limit may be changed in the future.
+ *
  * Api reference: https://core.telegram.org/bots/api#senddocument
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param document File to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files
@@ -45,9 +47,9 @@ class SendDocumentAction(document: ImplicitFile) :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun document(file: ImplicitFile) = SendDocumentAction(file)
 inline fun document(block: () -> String) = document(block().toImplicitFile())

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/MediaGroup.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/MediaGroup.kt
@@ -52,7 +52,9 @@ class SendMediaGroupAction(private val inputMedia: List<InputMedia>) :
 
 /**
  * Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendmediagroup
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param media A JSON-serialized array describing messages to be sent, must include 2-10 items
@@ -60,7 +62,7 @@ class SendMediaGroupAction(private val inputMedia: List<InputMedia>) :
  * @param protectContent Protects the contents of the sent messages from forwarding and saving
  * @param replyParameters Description of the message to reply to
  * @returns [Array of Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun sendMediaGroup(media: List<InputMedia>) = SendMediaGroupAction(media)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/MediaGroup.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/MediaGroup.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
 import eu.vendeli.tgbot.types.Message
@@ -19,6 +20,7 @@ import kotlin.collections.set
 
 class SendMediaGroupAction(private val inputMedia: List<InputMedia>) :
     MediaAction<List<Message>>(),
+    BusinessActionExt<List<Message>>,
     OptionsFeature<SendMediaGroupAction, MediaGroupOptions> {
     override val method = TgMethod("sendMediaGroup")
     override val returnType = getReturnType()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Photo.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Photo.kt
@@ -33,7 +33,9 @@ class SendPhotoAction(photo: ImplicitFile) :
 
 /**
  * Use this method to send photos. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendphoto
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param photo Photo to send. Pass a file_id as String to send a photo that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a photo from the Internet, or upload a new photo using multipart/form-data. The photo must be at most 10 MB in size. The photo's width and height must not exceed 10000 in total. Width and height ratio must be at most 20. More information on Sending Files: https://core.telegram.org/bots/api#sending-files
@@ -44,9 +46,9 @@ class SendPhotoAction(photo: ImplicitFile) :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun photo(file: ImplicitFile) = SendPhotoAction(file)
 inline fun photo(block: () -> String) = photo(block().toImplicitFile())

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Photo.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Photo.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.CaptionFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
@@ -17,6 +18,7 @@ import eu.vendeli.tgbot.utils.toImplicitFile
 
 class SendPhotoAction(photo: ImplicitFile) :
     MediaAction<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendPhotoAction, PhotoOptions>,
     MarkupFeature<SendPhotoAction>,
     CaptionFeature<SendPhotoAction> {

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Sticker.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Sticker.kt
@@ -31,17 +31,19 @@ class SendStickerAction(sticker: ImplicitFile) :
 
 /**
  * Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendsticker
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
- * @param sticker Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP sticker from the Internet, or upload a new .WEBP or .TGS sticker using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files. Video stickers can only be sent by a file_id. Animated stickers can't be sent via an HTTP URL.
+ * @param sticker Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP sticker from the Internet, or upload a new .WEBP, .TGS, or .WEBM sticker using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files. Video and animated stickers can't be sent via an HTTP URL.
  * @param emoji Emoji associated with the sticker; only for just uploaded stickers
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account.
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun sticker(file: ImplicitFile) = SendStickerAction(file)
 inline fun sticker(block: () -> String) = sticker(block().toImplicitFile())

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Sticker.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Sticker.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
@@ -16,6 +17,7 @@ import eu.vendeli.tgbot.utils.toImplicitFile
 
 class SendStickerAction(sticker: ImplicitFile) :
     MediaAction<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendStickerAction, StickerOptions>,
     MarkupFeature<SendStickerAction> {
     override val method = TgMethod("sendSticker")

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Video.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Video.kt
@@ -33,7 +33,9 @@ class SendVideoAction(video: ImplicitFile) :
 
 /**
  * Use this method to send video files, Telegram clients support MPEG4 videos (other formats may be sent as Document). On success, the sent Message is returned. Bots can currently send video files of up to 50 MB in size, this limit may be changed in the future.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendvideo
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param video Video to send. Pass a file_id as String to send a video that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a video from the Internet, or upload a new video using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files
@@ -49,9 +51,9 @@ class SendVideoAction(video: ImplicitFile) :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun video(file: ImplicitFile) = SendVideoAction(file)
 inline fun video(block: () -> String) = video(block().toImplicitFile())

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Video.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Video.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.CaptionFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
@@ -17,6 +18,7 @@ import eu.vendeli.tgbot.utils.toImplicitFile
 
 class SendVideoAction(video: ImplicitFile) :
     MediaAction<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendVideoAction, VideoOptions>,
     MarkupFeature<SendVideoAction>,
     CaptionFeature<SendVideoAction> {

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/VideoNote.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/VideoNote.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
@@ -16,6 +17,7 @@ import eu.vendeli.tgbot.utils.toImplicitFile
 
 class SendVideoNoteAction(videoNote: ImplicitFile) :
     MediaAction<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendVideoNoteAction, VideoNoteOptions>,
     MarkupFeature<SendVideoNoteAction> {
     override val method = TgMethod("sendVideoNote")

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/VideoNote.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/VideoNote.kt
@@ -31,7 +31,9 @@ class SendVideoNoteAction(videoNote: ImplicitFile) :
 
 /**
  * As of v.4.0, Telegram clients support rounded square MPEG4 videos of up to 1 minute long. Use this method to send video messages. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendvideonote
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param videoNote Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended) or upload a new video using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files. Sending video notes by a URL is currently unsupported
@@ -41,9 +43,9 @@ class SendVideoNoteAction(videoNote: ImplicitFile) :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun videoNote(file: ImplicitFile) = SendVideoNoteAction(file)
 inline fun videoNote(block: () -> String) = videoNote(block().toImplicitFile())

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Voice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Voice.kt
@@ -33,7 +33,9 @@ class SendVoiceAction(voice: ImplicitFile) :
 
 /**
  * Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendvoice
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param voice Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files
@@ -44,9 +46,9 @@ class SendVoiceAction(voice: ImplicitFile) :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun voice(file: ImplicitFile) = SendVoiceAction(file)
 inline fun voice(block: () -> String) = voice(block().toImplicitFile())

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Voice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/media/Voice.kt
@@ -2,6 +2,7 @@
 
 package eu.vendeli.tgbot.api.media
 
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.interfaces.features.CaptionFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
@@ -17,6 +18,7 @@ import eu.vendeli.tgbot.utils.toImplicitFile
 
 class SendVoiceAction(voice: ImplicitFile) :
     MediaAction<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendVoiceAction, VoiceOptions>,
     MarkupFeature<SendVoiceAction>,
     CaptionFeature<SendVoiceAction> {

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/CopyMessage.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/CopyMessage.kt
@@ -36,6 +36,7 @@ class CopyMessageAction(
 
 /**
  * Use this method to copy messages of any kind. Service messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied. A quiz poll can be copied only if the value of the field correct_option_id is known to the bot. The method is analogous to the method forwardMessage, but the copied message doesn't have a link to the original message. Returns the MessageId of the sent message on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#copymessage
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
@@ -49,7 +50,7 @@ class CopyMessageAction(
  * @param replyParameters Description of the message to reply to
  * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
  * @returns [MessageId]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun copyMessage(fromChatId: Identifier, messageId: Long) = CopyMessageAction(fromChatId, messageId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/CopyMessages.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/CopyMessages.kt
@@ -32,16 +32,17 @@ class CopyMessagesAction(
 
 /**
  * Use this method to copy messages of any kind. If some of the specified messages can't be found or copied, they are skipped. Service messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied. A quiz poll can be copied only if the value of the field correct_option_id is known to the bot. The method is analogous to the method forwardMessages, but the copied messages don't have a link to the original message. Album grouping is kept for copied messages. On success, an array of MessageId of the sent messages is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#copymessages
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param fromChatId Unique identifier for the chat where the original messages were sent (or channel username in the format @channelusername)
- * @param messageIds Identifiers of 1-100 messages in the chat from_chat_id to copy. The identifiers must be specified in a strictly increasing order.
+ * @param messageIds A JSON-serialized list of 1-100 identifiers of messages in the chat from_chat_id to copy. The identifiers must be specified in a strictly increasing order.
  * @param disableNotification Sends the messages silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent messages from forwarding and saving
  * @param removeCaption Pass True to copy the messages without their captions
  * @returns [Array of MessageId]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun copyMessages(fromChatId: Identifier, messageIds: List<Long>) =
     CopyMessagesAction(fromChatId, messageIds)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/DeleteMessage.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/DeleteMessage.kt
@@ -27,10 +27,11 @@ class DeleteMessageAction(messageId: Long) : Action<Boolean>() {
  * - If the bot is an administrator of a group, it can delete any message there.
  * - If the bot has can_delete_messages permission in a supergroup or a channel, it can delete any message there.
  * Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deletemessage
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Identifier of the message to delete
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteMessage(messageId: Long) = DeleteMessageAction(messageId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/DeleteMessages.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/DeleteMessages.kt
@@ -19,11 +19,12 @@ class DeleteMessagesAction(messageIds: List<Long>) : Action<Boolean>() {
 
 /**
  * Use this method to delete multiple messages simultaneously. If some of the specified messages can't be found, they are skipped. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deletemessages
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @param messageIds Identifiers of 1-100 messages to delete. See deleteMessage for limitations on which messages can be deleted
+ * @param messageIds A JSON-serialized list of 1-100 identifiers of messages to delete. See deleteMessage for limitations on which messages can be deleted
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteMessages(messageIds: List<Long>) = DeleteMessagesAction(messageIds)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageCaption.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageCaption.kt
@@ -28,6 +28,7 @@ class EditMessageCaptionAction() :
 
 /**
  * Use this method to edit captions of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#editmessagecaption
  * @param chatId Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Required if inline_message_id is not specified. Identifier of the message to edit
@@ -37,7 +38,7 @@ class EditMessageCaptionAction() :
  * @param captionEntities A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
  * @param replyMarkup A JSON-serialized object for an inline keyboard.
  * @returns [Message]|[Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun editMessageCaption(messageId: Long) = EditMessageCaptionAction(messageId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageCaption.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageCaption.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.tgbot.api.message
 
-import eu.vendeli.tgbot.interfaces.InlinableAction
+import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.InlineActionExt
 import eu.vendeli.tgbot.interfaces.features.CaptionFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
@@ -11,7 +12,8 @@ import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toJsonElement
 
 class EditMessageCaptionAction() :
-    InlinableAction<Message>(),
+    Action<Message>(),
+    InlineActionExt<Message>,
     OptionsFeature<EditMessageCaptionAction, EditCaptionOptions>,
     MarkupFeature<EditMessageCaptionAction>,
     CaptionFeature<EditMessageCaptionAction> {

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageLiveLocation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageLiveLocation.kt
@@ -35,6 +35,7 @@ class EditMessageLiveLocationAction :
 
 /**
  * Use this method to edit live location messages. A location can be edited until its live_period expires or editing is explicitly disabled by a call to stopMessageLiveLocation. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#editmessagelivelocation
  * @param chatId Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Required if inline_message_id is not specified. Identifier of the message to edit
@@ -46,7 +47,7 @@ class EditMessageLiveLocationAction :
  * @param proximityAlertRadius The maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
  * @param replyMarkup A JSON-serialized object for a new inline keyboard.
  * @returns [Message]|[Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun editMessageLiveLocation(messageId: Long, latitude: Float, longitude: Float) =
     EditMessageLiveLocationAction(messageId, latitude, longitude)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageLiveLocation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageLiveLocation.kt
@@ -2,7 +2,8 @@
 
 package eu.vendeli.tgbot.api.message
 
-import eu.vendeli.tgbot.interfaces.InlinableAction
+import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.InlineActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
 import eu.vendeli.tgbot.types.Message
@@ -12,7 +13,8 @@ import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toJsonElement
 
 class EditMessageLiveLocationAction :
-    InlinableAction<Message>,
+    Action<Message>,
+    InlineActionExt<Message>,
     OptionsFeature<EditMessageLiveLocationAction, EditMessageLiveLocationOptions>,
     MarkupFeature<EditMessageLiveLocationAction> {
     override val method = TgMethod("editMessageLiveLocation")

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageMedia.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageMedia.kt
@@ -45,6 +45,7 @@ class EditMessageMediaAction :
 
 /**
  * Use this method to edit animation, audio, document, photo, or video messages. If a message is part of a message album, then it can be edited only to an audio for audio albums, only to a document for document albums and to a photo or a video otherwise. When an inline message is edited, a new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#editmessagemedia
  * @param chatId Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Required if inline_message_id is not specified. Identifier of the message to edit
@@ -52,7 +53,7 @@ class EditMessageMediaAction :
  * @param media A JSON-serialized object for a new media content of the message
  * @param replyMarkup A JSON-serialized object for a new inline keyboard.
  * @returns [Message]|[Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun editMessageMedia(messageId: Long, inputMedia: InputMedia) = editMedia(messageId, inputMedia)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageMedia.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageMedia.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.tgbot.api.message
 
-import eu.vendeli.tgbot.interfaces.InlinableAction
+import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.InlineActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.types.Message
 import eu.vendeli.tgbot.types.internal.ImplicitFile
@@ -14,7 +15,8 @@ import eu.vendeli.tgbot.utils.toJsonElement
 import eu.vendeli.tgbot.utils.toPartData
 
 class EditMessageMediaAction :
-    InlinableAction<Message>,
+    Action<Message>,
+    InlineActionExt<Message>,
     MarkupFeature<EditMessageMediaAction> {
     override val method = TgMethod("editMessageMedia")
     override val returnType = getReturnType()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageReplyMarkup.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageReplyMarkup.kt
@@ -2,7 +2,8 @@
 
 package eu.vendeli.tgbot.api.message
 
-import eu.vendeli.tgbot.interfaces.InlinableAction
+import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.InlineActionExt
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.types.Message
 import eu.vendeli.tgbot.types.internal.TgMethod
@@ -10,7 +11,8 @@ import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toJsonElement
 
 class EditMessageReplyMarkupAction() :
-    InlinableAction<Message>(),
+    Action<Message>(),
+    InlineActionExt<Message>,
     MarkupFeature<EditMessageReplyMarkupAction> {
     override val method = TgMethod("editMessageReplyMarkup")
     override val returnType = getReturnType()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageReplyMarkup.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageReplyMarkup.kt
@@ -24,13 +24,14 @@ class EditMessageReplyMarkupAction() :
 
 /**
  * Use this method to edit only the reply markup of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#editmessagereplymarkup
  * @param chatId Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Required if inline_message_id is not specified. Identifier of the message to edit
  * @param inlineMessageId Required if chat_id and message_id are not specified. Identifier of the inline message
  * @param replyMarkup A JSON-serialized object for an inline keyboard.
  * @returns [Message]|[Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun editMessageReplyMarkup() = editMarkup()
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageText.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageText.kt
@@ -39,6 +39,7 @@ class EditMessageTextAction private constructor() :
 
 /**
  * Use this method to edit text and game messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#editmessagetext
  * @param chatId Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageId Required if inline_message_id is not specified. Identifier of the message to edit
@@ -49,7 +50,7 @@ class EditMessageTextAction private constructor() :
  * @param linkPreviewOptions Link preview generation options for the message
  * @param replyMarkup A JSON-serialized object for an inline keyboard.
  * @returns [Message]|[Boolean]
-*/
+ */
 inline fun editMessageText(messageId: Long, block: () -> String) = editText(messageId, block)
 
 fun editMessageText(block: EntitiesContextBuilder<EditMessageTextAction>.() -> String) = EditMessageTextAction(block)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageText.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/EditMessageText.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.tgbot.api.message
 
-import eu.vendeli.tgbot.interfaces.InlinableAction
+import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.InlineActionExt
 import eu.vendeli.tgbot.interfaces.features.EntitiesFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
@@ -12,7 +13,8 @@ import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toJsonElement
 
 class EditMessageTextAction private constructor() :
-    InlinableAction<Message>(),
+    Action<Message>(),
+    InlineActionExt<Message>,
     EntitiesContextBuilder<EditMessageTextAction>,
     OptionsFeature<EditMessageTextAction, EditMessageOptions>,
     MarkupFeature<EditMessageTextAction>,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/ForwardMessage.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/ForwardMessage.kt
@@ -30,6 +30,7 @@ class ForwardMessageAction(fromChatId: Identifier, messageId: Long) :
 
 /**
  * Use this method to forward messages of any kind. Service messages and messages with protected content can't be forwarded. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#forwardmessage
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
@@ -38,7 +39,7 @@ class ForwardMessageAction(fromChatId: Identifier, messageId: Long) :
  * @param protectContent Protects the contents of the forwarded message from forwarding and saving
  * @param messageId Message identifier in the chat specified in from_chat_id
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun forwardMessage(fromChatId: Identifier, messageId: Long) = ForwardMessageAction(fromChatId, messageId)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/ForwardMessages.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/ForwardMessages.kt
@@ -30,15 +30,16 @@ class ForwardMessagesAction(fromChatId: Identifier, messageIds: List<Long>) :
 
 /**
  * Use this method to forward multiple messages of any kind. If some of the specified messages can't be found or forwarded, they are skipped. Service messages and messages with protected content can't be forwarded. Album grouping is kept for forwarded messages. On success, an array of MessageId of the sent messages is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#forwardmessages
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param fromChatId Unique identifier for the chat where the original messages were sent (or channel username in the format @channelusername)
- * @param messageIds Identifiers of 1-100 messages in the chat from_chat_id to forward. The identifiers must be specified in a strictly increasing order.
+ * @param messageIds A JSON-serialized list of 1-100 identifiers of messages in the chat from_chat_id to forward. The identifiers must be specified in a strictly increasing order.
  * @param disableNotification Sends the messages silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the forwarded messages from forwarding and saving
  * @returns [Array of MessageId]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun forwardMessages(fromChatId: Identifier, messageIds: List<Long>) =
     ForwardMessagesAction(fromChatId, messageIds)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/Message.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/Message.kt
@@ -3,6 +3,7 @@
 package eu.vendeli.tgbot.api.message
 
 import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.interfaces.BusinessActionExt
 import eu.vendeli.tgbot.interfaces.features.EntitiesFeature
 import eu.vendeli.tgbot.interfaces.features.MarkupFeature
 import eu.vendeli.tgbot.interfaces.features.OptionsFeature
@@ -15,6 +16,7 @@ import eu.vendeli.tgbot.utils.toJsonElement
 
 class SendMessageAction private constructor() :
     Action<Message>(),
+    BusinessActionExt<Message>,
     OptionsFeature<SendMessageAction, MessageOptions>,
     MarkupFeature<SendMessageAction>,
     EntitiesFeature<SendMessageAction>,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/Message.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/message/Message.kt
@@ -36,7 +36,9 @@ class SendMessageAction private constructor() :
 
 /**
  * Use this method to send text messages. On success, the sent Message is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#sendmessage
+ * @param businessConnectionId Unique identifier of the business connection on behalf of which the message will be sent
  * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @param messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @param text Text of the message to be sent, 1-4096 characters after entities parsing
@@ -46,9 +48,9 @@ class SendMessageAction private constructor() :
  * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
  * @param protectContent Protects the contents of the sent message from forwarding and saving
  * @param replyParameters Description of the message to reply to
- * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @param replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
  * @returns [Message]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun message(text: String) = SendMessageAction(text)
 fun message(block: EntitiesContextBuilder<SendMessageAction>.() -> String) = SendMessageAction(block)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/AddStickerToSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/AddStickerToSet.kt
@@ -35,13 +35,14 @@ class AddStickerToSetAction(
 }
 
 /**
- * Use this method to add a new sticker to a set created by the bot. The format of the added sticker must match the format of the other stickers in the set. Emoji sticker sets can have up to 200 stickers. Animated and video sticker sets can have up to 50 stickers. Static sticker sets can have up to 120 stickers. Returns True on success.
+ * Use this method to add a new sticker to a set created by the bot. Emoji sticker sets can have up to 200 stickers. Other sticker sets can have up to 120 stickers. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#addstickertoset
  * @param userId User identifier of sticker set owner
  * @param name Sticker set name
  * @param sticker A JSON-serialized object with information about the added sticker. If exactly the same sticker had already been added to the set, then the set isn't changed.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun addStickerToSet(name: String, input: InputSticker) = AddStickerToSetAction(name, input)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/AddStickerToSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/AddStickerToSet.kt
@@ -3,11 +3,14 @@
 package eu.vendeli.tgbot.api.stickerset
 
 import eu.vendeli.tgbot.interfaces.MediaAction
+import eu.vendeli.tgbot.types.internal.ImplicitFile
 import eu.vendeli.tgbot.types.internal.TgMethod
 import eu.vendeli.tgbot.types.media.InputSticker
 import eu.vendeli.tgbot.utils.encodeWith
 import eu.vendeli.tgbot.utils.getReturnType
+import eu.vendeli.tgbot.utils.toImplicitFile
 import eu.vendeli.tgbot.utils.toJsonElement
+import eu.vendeli.tgbot.utils.toPartData
 import kotlin.collections.set
 
 class AddStickerToSetAction(
@@ -20,7 +23,14 @@ class AddStickerToSetAction(
 
     init {
         parameters["name"] = name.toJsonElement()
-        parameters["sticker"] = input.encodeWith(InputSticker.serializer())
+        parameters["sticker"] = input.also {
+            if (it.sticker is ImplicitFile.InpFile) {
+                val inpSticker = it.sticker as ImplicitFile.InpFile
+                multipartData += inpSticker.file.toPartData(inpSticker.file.fileName)
+
+                it.sticker = "attach://${inpSticker.file.fileName}".toImplicitFile()
+            }
+        }.encodeWith(InputSticker.serializer())
     }
 }
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/CreateNewStickerSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/CreateNewStickerSet.kt
@@ -40,16 +40,16 @@ class CreateNewStickerSetAction(
 
 /**
  * Use this method to create a new sticker set owned by a user. The bot will be able to edit the sticker set thus created. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#createnewstickerset
  * @param userId User identifier of created sticker set owner
  * @param name Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only English letters, digits and underscores. Must begin with a letter, can't contain consecutive underscores and must end in "_by_<bot_username>". <bot_username> is case insensitive. 1-64 characters.
  * @param title Sticker set title, 1-64 characters
  * @param stickers A JSON-serialized list of 1-50 initial stickers to be added to the sticker set
- * @param stickerFormat Format of stickers in the set, must be one of "static", "animated", "video"
  * @param stickerType Type of stickers in the set, pass "regular", "mask", or "custom_emoji". By default, a regular sticker set is created.
  * @param needsRepainting Pass True if stickers in the sticker set must be repainted to the color of text when used in messages, the accent color if used as emoji status, white on chat photos, or another appropriate color based on context; for custom emoji sticker sets only
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun createNewStickerSet(
     name: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/CreateNewStickerSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/CreateNewStickerSet.kt
@@ -8,7 +8,6 @@ import eu.vendeli.tgbot.types.internal.ImplicitFile
 import eu.vendeli.tgbot.types.internal.TgMethod
 import eu.vendeli.tgbot.types.internal.options.CreateNewStickerSetOptions
 import eu.vendeli.tgbot.types.media.InputSticker
-import eu.vendeli.tgbot.types.media.StickerFormat
 import eu.vendeli.tgbot.utils.encodeWith
 import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.toImplicitFile
@@ -18,7 +17,6 @@ import eu.vendeli.tgbot.utils.toPartData
 class CreateNewStickerSetAction(
     name: String,
     title: String,
-    stickerFormat: StickerFormat,
     stickers: List<InputSticker>,
 ) : MediaAction<Boolean>(), OptionsFeature<CreateNewStickerSetAction, CreateNewStickerSetOptions> {
     override val method = TgMethod("createNewStickerSet")
@@ -29,7 +27,6 @@ class CreateNewStickerSetAction(
     init {
         parameters["name"] = name.toJsonElement()
         parameters["title"] = title.toJsonElement()
-        parameters["sticker_format"] = stickerFormat.encodeWith(StickerFormat.serializer())
         parameters["stickers"] = stickers.onEach {
             if (it.sticker is ImplicitFile.InpFile) {
                 val sticker = it.sticker as ImplicitFile.InpFile
@@ -57,6 +54,5 @@ class CreateNewStickerSetAction(
 inline fun createNewStickerSet(
     name: String,
     title: String,
-    stickerFormat: StickerFormat,
     stickers: List<InputSticker>,
-) = CreateNewStickerSetAction(name, title, stickerFormat, stickers)
+) = CreateNewStickerSetAction(name, title, stickers)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/DeleteStickerFromSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/DeleteStickerFromSet.kt
@@ -18,9 +18,10 @@ class DeleteStickerFromSetAction(sticker: String) : SimpleAction<Boolean>() {
 
 /**
  * Use this method to delete a sticker from a set created by the bot. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deletestickerfromset
  * @param sticker File identifier of the sticker
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteStickerFromSet(sticker: String) = DeleteStickerFromSetAction(sticker)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/DeleteStickerSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/DeleteStickerSet.kt
@@ -18,9 +18,10 @@ class DeleteStickerSetAction(name: String) : SimpleAction<Boolean>() {
 
 /**
  * Use this method to delete a sticker set that was created by the bot. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#deletestickerset
  * @param name Sticker set name
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun deleteStickerSet(name: String) = DeleteStickerSetAction(name)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/GetCustomEmojiStickers.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/GetCustomEmojiStickers.kt
@@ -21,10 +21,11 @@ class GetCustomEmojiStickersAction(customEmojiIds: List<String>) : SimpleAction<
 
 /**
  * Use this method to get information about custom emoji stickers by their identifiers. Returns an Array of Sticker objects.
+ *
  * Api reference: https://core.telegram.org/bots/api#getcustomemojistickers
- * @param customEmojiIds List of custom emoji identifiers. At most 200 custom emoji identifiers can be specified.
+ * @param customEmojiIds A JSON-serialized list of custom emoji identifiers. At most 200 custom emoji identifiers can be specified.
  * @returns [Array of Sticker]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getCustomEmojiStickers(customEmojiIds: List<String>) = GetCustomEmojiStickersAction(customEmojiIds)
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/GetStickerSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/GetStickerSet.kt
@@ -19,9 +19,10 @@ class GetStickerSetAction(name: String) : SimpleAction<StickerSet>() {
 
 /**
  * Use this method to get a sticker set. On success, a StickerSet object is returned.
+ *
  * Api reference: https://core.telegram.org/bots/api#getstickerset
  * @param name Name of the sticker set
  * @returns [StickerSet]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun getStickerSet(name: String) = GetStickerSetAction(name)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/ReplaceStickerInSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/ReplaceStickerInSet.kt
@@ -13,6 +13,7 @@ import eu.vendeli.tgbot.utils.toJsonElement
 import eu.vendeli.tgbot.utils.toPartData
 
 class ReplaceStickerInSetAction(
+    userId: Long,
     name: String,
     oldSticker: String,
     sticker: InputSticker,
@@ -21,6 +22,7 @@ class ReplaceStickerInSetAction(
     override val returnType = getReturnType()
 
     init {
+        parameters["user_id"] = userId.toJsonElement()
         parameters["name"] = name.toJsonElement()
         parameters["old_sticker"] = oldSticker.toJsonElement()
         parameters["sticker"] = sticker.also {
@@ -45,4 +47,9 @@ class ReplaceStickerInSetAction(
  * @returns [Boolean]
  */
 @Suppress("NOTHING_TO_INLINE")
-inline fun replaceStickerInSet(name: String) = DeleteStickerSetAction(name)
+inline fun replaceStickerInSet(
+    userId: Long,
+    name: String,
+    oldSticker: String,
+    sticker: InputSticker,
+) = ReplaceStickerInSetAction(userId, name, oldSticker, sticker)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/ReplaceStickerInSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/ReplaceStickerInSet.kt
@@ -34,5 +34,15 @@ class ReplaceStickerInSetAction(
     }
 }
 
+/**
+ * Use this method to replace an existing sticker in a sticker set with a new one. The method is equivalent to calling deleteStickerFromSet, then addStickerToSet, then setStickerPositionInSet. Returns True on success.
+ *
+ * Api reference: https://core.telegram.org/bots/api#replacestickerinset
+ * @param userId User identifier of the sticker set owner
+ * @param name Sticker set name
+ * @param oldSticker File identifier of the replaced sticker
+ * @param sticker A JSON-serialized object with information about the added sticker. If exactly the same sticker had already been added to the set, then the set remains unchanged.
+ * @returns [Boolean]
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun replaceStickerInSet(name: String) = DeleteStickerSetAction(name)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/ReplaceStickerInSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/ReplaceStickerInSet.kt
@@ -1,0 +1,38 @@
+@file:Suppress("MatchingDeclarationName")
+
+package eu.vendeli.tgbot.api.stickerset
+
+import eu.vendeli.tgbot.interfaces.Action
+import eu.vendeli.tgbot.types.internal.ImplicitFile
+import eu.vendeli.tgbot.types.internal.TgMethod
+import eu.vendeli.tgbot.types.media.InputSticker
+import eu.vendeli.tgbot.utils.encodeWith
+import eu.vendeli.tgbot.utils.getReturnType
+import eu.vendeli.tgbot.utils.toImplicitFile
+import eu.vendeli.tgbot.utils.toJsonElement
+import eu.vendeli.tgbot.utils.toPartData
+
+class ReplaceStickerInSetAction(
+    name: String,
+    oldSticker: String,
+    sticker: InputSticker,
+) : Action<Boolean>() {
+    override val method = TgMethod("replaceStickerInSet")
+    override val returnType = getReturnType()
+
+    init {
+        parameters["name"] = name.toJsonElement()
+        parameters["old_sticker"] = oldSticker.toJsonElement()
+        parameters["sticker"] = sticker.also {
+            if (it.sticker is ImplicitFile.InpFile) {
+                val inpSticker = it.sticker as ImplicitFile.InpFile
+                multipartData += inpSticker.file.toPartData(inpSticker.file.fileName)
+
+                it.sticker = "attach://${inpSticker.file.fileName}".toImplicitFile()
+            }
+        }.encodeWith(InputSticker.serializer())
+    }
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun replaceStickerInSet(name: String) = DeleteStickerSetAction(name)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetCustomEmojiStickerSetThumbnail.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetCustomEmojiStickerSetThumbnail.kt
@@ -22,11 +22,12 @@ class SetCustomEmojiStickerSetThumbnailAction(
 
 /**
  * Use this method to set the thumbnail of a custom emoji sticker set. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setcustomemojistickersetthumbnail
  * @param name Sticker set name
  * @param customEmojiId Custom emoji identifier of a sticker from the sticker set; pass an empty string to drop the thumbnail and use the first sticker as the thumbnail.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setCustomEmojiStickerSetThumbnail(name: String, customEmojiId: String? = null) =
     SetCustomEmojiStickerSetThumbnailAction(name, customEmojiId)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerEmojiList.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerEmojiList.kt
@@ -24,11 +24,12 @@ class SetStickerEmojiListAction(
 
 /**
  * Use this method to change the list of emoji assigned to a regular or custom emoji sticker. The sticker must belong to a sticker set created by the bot. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setstickeremojilist
  * @param sticker File identifier of the sticker
  * @param emojiList A JSON-serialized list of 1-20 emoji associated with the sticker
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setStickerEmojiList(sticker: String, emojiList: List<String>) =
     SetStickerEmojiListAction(sticker, emojiList)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerKeywords.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerKeywords.kt
@@ -24,11 +24,12 @@ class SetStickerKeywordsAction(
 
 /**
  * Use this method to change search keywords assigned to a regular or custom emoji sticker. The sticker must belong to a sticker set created by the bot. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setstickerkeywords
  * @param sticker File identifier of the sticker
  * @param keywords A JSON-serialized list of 0-20 search keywords for the sticker with total length of up to 64 characters
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setStickerKeywords(sticker: String, keywords: List<String>? = null) =
     SetStickerKeywordsAction(sticker, keywords)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerMaskPosition.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerMaskPosition.kt
@@ -24,11 +24,12 @@ class SetStickerMaskPositionAction(
 
 /**
  * Use this method to change the mask position of a mask sticker. The sticker must belong to a sticker set that was created by the bot. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setstickermaskposition
  * @param sticker File identifier of the sticker
  * @param maskPosition A JSON-serialized object with the position where the mask should be placed on faces. Omit the parameter to remove the mask position.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setStickerMaskPosition(sticker: String, maskPosition: MaskPosition? = null) =
     SetStickerMaskPositionAction(sticker, maskPosition)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerPositionInSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerPositionInSet.kt
@@ -19,10 +19,11 @@ class SetStickerPositionInSetAction(sticker: String, position: Int) : SimpleActi
 
 /**
  * Use this method to move a sticker in a set created by the bot to a specific position. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setstickerpositioninset
  * @param sticker File identifier of the sticker
  * @param position New sticker position in the set, zero-based
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setStickerPositionInSet(sticker: String, position: Int) = SetStickerPositionInSetAction(sticker, position)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnail.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnail.kt
@@ -29,10 +29,12 @@ class SetStickerSetThumbnailAction(
 
 /**
  * Use this method to set the thumbnail of a regular or mask sticker set. The format of the thumbnail file must match the format of the stickers in the set. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setstickersetthumbnail
  * @param name Sticker set name
  * @param userId User identifier of the sticker set owner
  * @param thumbnail A .WEBP or .PNG image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a .TGS animation with a thumbnail up to 32 kilobytes in size (see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements), or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files. Animated and video sticker set thumbnails can't be uploaded via HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail.
+ * @param format Format of the thumbnail, must be one of "static" for a .WEBP or .PNG image, "animated" for a .TGS animation, or "video" for a WEBM video
  * @returns [Boolean]
  */
 @Suppress("NOTHING_TO_INLINE")

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnail.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerSetThumbnail.kt
@@ -5,12 +5,15 @@ package eu.vendeli.tgbot.api.stickerset
 import eu.vendeli.tgbot.interfaces.MediaAction
 import eu.vendeli.tgbot.types.internal.ImplicitFile
 import eu.vendeli.tgbot.types.internal.TgMethod
+import eu.vendeli.tgbot.types.media.StickerFormat
+import eu.vendeli.tgbot.utils.encodeWith
 import eu.vendeli.tgbot.utils.getReturnType
 import eu.vendeli.tgbot.utils.handleImplicitFile
 import eu.vendeli.tgbot.utils.toJsonElement
 
 class SetStickerSetThumbnailAction(
     name: String,
+    format: StickerFormat,
     thumbnail: ImplicitFile? = null,
 ) : MediaAction<Boolean>() {
     override val method = TgMethod("setStickerSetThumbnail")
@@ -20,6 +23,7 @@ class SetStickerSetThumbnailAction(
     init {
         if (thumbnail != null) handleImplicitFile(thumbnail, "thumbnail")
         parameters["name"] = name.toJsonElement()
+        parameters["format"] = format.encodeWith(StickerFormat.serializer())
     }
 }
 
@@ -30,7 +34,7 @@ class SetStickerSetThumbnailAction(
  * @param userId User identifier of the sticker set owner
  * @param thumbnail A .WEBP or .PNG image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a .TGS animation with a thumbnail up to 32 kilobytes in size (see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements), or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More information on Sending Files: https://core.telegram.org/bots/api#sending-files. Animated and video sticker set thumbnails can't be uploaded via HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail.
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
-inline fun setStickerSetThumbnail(name: String, thumbnail: ImplicitFile? = null) =
-    SetStickerSetThumbnailAction(name, thumbnail)
+inline fun setStickerSetThumbnail(name: String, format: StickerFormat, thumbnail: ImplicitFile? = null) =
+    SetStickerSetThumbnailAction(name, format, thumbnail)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerSetTitle.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/SetStickerSetTitle.kt
@@ -22,10 +22,11 @@ class SetStickerSetTitleAction(
 
 /**
  * Use this method to set the title of a created sticker set. Returns True on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#setstickersettitle
  * @param name Sticker set name
  * @param title Sticker set title, 1-64 characters
  * @returns [Boolean]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun setStickerSetTitle(name: String, title: String) = SetStickerSetTitleAction(name, title)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/UploadStickerFile.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/api/stickerset/UploadStickerFile.kt
@@ -26,13 +26,14 @@ class UploadStickerFileAction(sticker: InputFile, stickerFormat: StickerFormat) 
 }
 
 /**
- * Use this method to upload a file with a sticker for later use in the createNewStickerSet and addStickerToSet methods (the file can be used multiple times). Returns the uploaded File on success.
+ * Use this method to upload a file with a sticker for later use in the createNewStickerSet, addStickerToSet, or replaceStickerInSet methods (the file can be used multiple times). Returns the uploaded File on success.
+ *
  * Api reference: https://core.telegram.org/bots/api#uploadstickerfile
  * @param userId User identifier of sticker file owner
  * @param sticker A file with the sticker in .WEBP, .PNG, .TGS, or .WEBM format. See https://core.telegram.org/stickers for technical requirements. More information on Sending Files: https://core.telegram.org/bots/api#sending-files
  * @param stickerFormat Format of the sticker, must be one of "static", "animated", "video"
  * @returns [File]
-*/
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun uploadStickerFile(sticker: InputFile, stickerFormat: StickerFormat) =
     UploadStickerFileAction(sticker, stickerFormat)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/core/CodegenUpdateHandler.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/core/CodegenUpdateHandler.kt
@@ -67,8 +67,9 @@ class CodegenUpdateHandler internal constructor(
         when {
             invocation != null -> invocation.invokeCatching(this, user, request.params)
 
-            activities.unprocessedHandler != null -> activities.unprocessedHandler!!
-                .invokeCatching(this, request.params)
+            activities.unprocessedHandler != null ->
+                activities.unprocessedHandler!!
+                    .invokeCatching(this, request.params)
 
             else -> logger.warn { "update: $update not handled." }
         }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/core/FunctionalHandlingDsl.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/core/FunctionalHandlingDsl.kt
@@ -10,6 +10,8 @@ import eu.vendeli.tgbot.types.internal.SingleInputChain
 import eu.vendeli.tgbot.types.internal.UpdateType
 import eu.vendeli.tgbot.types.internal.configuration.RateLimits
 import eu.vendeli.tgbot.utils.DEFAULT_COMMAND_SCOPE
+import eu.vendeli.tgbot.utils.OnBusinessConnectionActivity
+import eu.vendeli.tgbot.utils.OnBusinessMessageActivity
 import eu.vendeli.tgbot.utils.OnCallbackQueryActivity
 import eu.vendeli.tgbot.utils.OnChannelPostActivity
 import eu.vendeli.tgbot.utils.OnChatBoostActivity
@@ -17,6 +19,8 @@ import eu.vendeli.tgbot.utils.OnChatJoinRequestActivity
 import eu.vendeli.tgbot.utils.OnChatMemberActivity
 import eu.vendeli.tgbot.utils.OnChosenInlineResultActivity
 import eu.vendeli.tgbot.utils.OnCommandActivity
+import eu.vendeli.tgbot.utils.OnDeletedBusinessMessagesActivity
+import eu.vendeli.tgbot.utils.OnEditedBusinessMessageActivity
 import eu.vendeli.tgbot.utils.OnEditedChannelPostActivity
 import eu.vendeli.tgbot.utils.OnEditedMessageActivity
 import eu.vendeli.tgbot.utils.OnInlineQueryActivity
@@ -168,6 +172,34 @@ class FunctionalHandlingDsl internal constructor(
      */
     fun onRemovedChatBoost(block: OnRemovedChatBoostActivity) {
         functionalActivities.onUpdateActivities[UpdateType.REMOVED_CHAT_BOOST] = block.cast()
+    }
+
+    /**
+     * Action that is performed on the presence of BusinessConnection in the Update.
+     */
+    fun onBusinessConnection(block: OnBusinessConnectionActivity) {
+        functionalActivities.onUpdateActivities[UpdateType.BUSINESS_CONNECTION] = block.cast()
+    }
+
+    /**
+     * Action that is performed on the presence of BusinessMessage in the Update.
+     */
+    fun onBusinessMessage(block: OnBusinessMessageActivity) {
+        functionalActivities.onUpdateActivities[UpdateType.BUSINESS_MESSAGE] = block.cast()
+    }
+
+    /**
+     * Action that is performed on the presence of EditedBusinessMessage in the Update.
+     */
+    fun onEditedBusinessMessage(block: OnEditedBusinessMessageActivity) {
+        functionalActivities.onUpdateActivities[UpdateType.EDITED_BUSINESS_MESSAGE] = block.cast()
+    }
+
+    /**
+     * Action that is performed on the presence of DeletedBusinessMessages in the Update.
+     */
+    fun onDeletedBusinessMessages(block: OnDeletedBusinessMessagesActivity) {
+        functionalActivities.onUpdateActivities[UpdateType.DELETED_BUSINESS_MESSAGES] = block.cast()
     }
 
     /**

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/Action.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/Action.kt
@@ -4,8 +4,6 @@ import eu.vendeli.tgbot.TelegramBot
 import eu.vendeli.tgbot.types.User
 import eu.vendeli.tgbot.types.chat.Chat
 import eu.vendeli.tgbot.types.internal.Response
-import eu.vendeli.tgbot.utils.makeRequestAsync
-import eu.vendeli.tgbot.utils.makeSilentRequest
 import eu.vendeli.tgbot.utils.toJsonElement
 import kotlinx.coroutines.Deferred
 
@@ -23,22 +21,22 @@ abstract class Action<ReturnType> : TgAction<ReturnType>() {
      */
     open suspend fun send(to: String, via: TelegramBot) {
         parameters["chat_id"] = to.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        doRequest(via)
     }
 
     open suspend fun send(to: Long, via: TelegramBot) {
         parameters["chat_id"] = to.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        doRequest(via)
     }
 
     open suspend fun send(to: User, via: TelegramBot) {
         parameters["chat_id"] = to.id.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        doRequest(via)
     }
 
     open suspend fun send(to: Chat, via: TelegramBot) {
         parameters["chat_id"] = to.id.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        doRequest(via)
     }
 
     /**
@@ -52,7 +50,7 @@ abstract class Action<ReturnType> : TgAction<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters["chat_id"] = to.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        return doRequestAsync(via)
     }
 
     open suspend fun sendAsync(
@@ -60,7 +58,7 @@ abstract class Action<ReturnType> : TgAction<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters["chat_id"] = to.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        return doRequestAsync(via)
     }
 
     open suspend fun sendAsync(
@@ -68,7 +66,7 @@ abstract class Action<ReturnType> : TgAction<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters["chat_id"] = to.id.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        return doRequestAsync(via)
     }
 
     open suspend fun sendAsync(
@@ -76,6 +74,6 @@ abstract class Action<ReturnType> : TgAction<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters["chat_id"] = to.id.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        return doRequestAsync(via)
     }
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/Autowiring.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/Autowiring.kt
@@ -8,7 +8,7 @@ import eu.vendeli.tgbot.types.internal.ProcessedUpdate
  *
  * @param T
  */
-fun interface Autowiring<T> {
+interface Autowiring<T : Any> {
     /**
      * method which will be used to retrieve the object.
      *

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/BusinessActionExt.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/BusinessActionExt.kt
@@ -1,0 +1,38 @@
+package eu.vendeli.tgbot.interfaces
+
+import eu.vendeli.tgbot.TelegramBot
+import eu.vendeli.tgbot.types.internal.Response
+import eu.vendeli.tgbot.utils.toJsonElement
+import kotlinx.coroutines.Deferred
+
+/**
+ * Provides the ability to do business request.
+ *
+ * @param ReturnType
+ */
+interface BusinessActionExt<ReturnType> : Request<ReturnType> {
+    /**
+     * Make business request for action.
+     *
+     * @param businessConnectionId Identifier of the inline message
+     * @param via Instance of the bot through which the request will be made.
+     */
+    suspend fun sendBusiness(businessConnectionId: String, via: TelegramBot) {
+        getParameters()["business_connection_id"] = businessConnectionId.toJsonElement()
+        doRequest(via)
+    }
+
+    /**
+     * Make a request for action returning its [Response].
+     *
+     * @param businessConnectionId Identifier of the inline message
+     * @param via Instance of the bot through which the request will be made.
+     */
+    suspend fun sendBusinessAsync(
+        businessConnectionId: String,
+        via: TelegramBot,
+    ): Deferred<Response<out ReturnType>> {
+        getParameters()["business_connection_id"] = businessConnectionId.toJsonElement()
+        return doRequestAsync(via)
+    }
+}

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/InlineActionExt.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/InlineActionExt.kt
@@ -2,8 +2,6 @@ package eu.vendeli.tgbot.interfaces
 
 import eu.vendeli.tgbot.TelegramBot
 import eu.vendeli.tgbot.types.internal.Response
-import eu.vendeli.tgbot.utils.makeRequestAsync
-import eu.vendeli.tgbot.utils.makeSilentRequest
 import eu.vendeli.tgbot.utils.toJsonElement
 import kotlinx.coroutines.Deferred
 
@@ -12,7 +10,7 @@ import kotlinx.coroutines.Deferred
  *
  * @param ReturnType
  */
-abstract class InlinableAction<ReturnType> : Action<ReturnType>() {
+interface InlineActionExt<ReturnType> : Request<ReturnType> {
     /**
      * Make inline request for action.
      *
@@ -20,8 +18,8 @@ abstract class InlinableAction<ReturnType> : Action<ReturnType>() {
      * @param via Instance of the bot through which the request will be made.
      */
     suspend fun sendInline(inlineMessageId: String, via: TelegramBot) {
-        parameters["inline_message_id"] = inlineMessageId.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        getParameters()["inline_message_id"] = inlineMessageId.toJsonElement()
+        doRequest(via)
     }
 
     /**
@@ -34,7 +32,7 @@ abstract class InlinableAction<ReturnType> : Action<ReturnType>() {
         inlineMessageId: String,
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
-        parameters["inline_message_id"] = inlineMessageId.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        getParameters()["inline_message_id"] = inlineMessageId.toJsonElement()
+        return doRequestAsync(via)
     }
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/MediaAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/MediaAction.kt
@@ -8,9 +8,6 @@ import eu.vendeli.tgbot.utils.makeRequestAsync
 import eu.vendeli.tgbot.utils.makeSilentRequest
 import eu.vendeli.tgbot.utils.toJsonElement
 import kotlinx.coroutines.Deferred
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.JsonUnquotedLiteral
-import kotlinx.serialization.json.jsonPrimitive
 import kotlin.collections.set
 
 /**
@@ -32,25 +29,21 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
      */
     override suspend fun send(to: String, via: TelegramBot) {
         parameters[idRefField] = to.toJsonElement()
-        handleParseModeInMultipart()
         via.makeSilentRequest(method, parameters, multipartData)
     }
 
     override suspend fun send(to: Long, via: TelegramBot) {
         parameters[idRefField] = to.toJsonElement()
-        handleParseModeInMultipart()
         via.makeSilentRequest(method, parameters, multipartData)
     }
 
     override suspend fun send(to: User, via: TelegramBot) {
         parameters[idRefField] = to.id.toJsonElement()
-        handleParseModeInMultipart()
         via.makeSilentRequest(method, parameters, multipartData)
     }
 
     override suspend fun send(to: Chat, via: TelegramBot) {
         parameters[idRefField] = to.id.toJsonElement()
-        handleParseModeInMultipart()
         via.makeSilentRequest(method, parameters, multipartData)
     }
 
@@ -65,7 +58,6 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.toJsonElement()
-        handleParseModeInMultipart()
         return via.makeRequestAsync(method, parameters, returnType, multipartData)
     }
 
@@ -74,7 +66,6 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.toJsonElement()
-        handleParseModeInMultipart()
         return via.makeRequestAsync(method, parameters, returnType, multipartData)
     }
 
@@ -83,7 +74,6 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.id.toJsonElement()
-        handleParseModeInMultipart()
         return via.makeRequestAsync(method, parameters, returnType, multipartData)
     }
 
@@ -92,14 +82,6 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.id.toJsonElement()
-        handleParseModeInMultipart()
         return via.makeRequestAsync(method, parameters, returnType, multipartData)
-    }
-
-    @OptIn(ExperimentalSerializationApi::class)
-    private fun handleParseModeInMultipart() {
-        if (multipartData.isNotEmpty()) parameters["parse_mode"]?.let {
-            parameters["parse_mode"] = JsonUnquotedLiteral(it.jsonPrimitive.content)
-        }
     }
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/MediaAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/MediaAction.kt
@@ -4,8 +4,6 @@ import eu.vendeli.tgbot.TelegramBot
 import eu.vendeli.tgbot.types.User
 import eu.vendeli.tgbot.types.chat.Chat
 import eu.vendeli.tgbot.types.internal.Response
-import eu.vendeli.tgbot.utils.makeRequestAsync
-import eu.vendeli.tgbot.utils.makeSilentRequest
 import eu.vendeli.tgbot.utils.toJsonElement
 import kotlinx.coroutines.Deferred
 import kotlin.collections.set
@@ -29,22 +27,22 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
      */
     override suspend fun send(to: String, via: TelegramBot) {
         parameters[idRefField] = to.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        doRequest(via)
     }
 
     override suspend fun send(to: Long, via: TelegramBot) {
         parameters[idRefField] = to.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        doRequest(via)
     }
 
     override suspend fun send(to: User, via: TelegramBot) {
         parameters[idRefField] = to.id.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        doRequest(via)
     }
 
     override suspend fun send(to: Chat, via: TelegramBot) {
         parameters[idRefField] = to.id.toJsonElement()
-        via.makeSilentRequest(method, parameters, multipartData)
+        doRequest(via)
     }
 
     /**
@@ -58,7 +56,7 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        return doRequestAsync(via)
     }
 
     override suspend fun sendAsync(
@@ -66,7 +64,7 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        return doRequestAsync(via)
     }
 
     override suspend fun sendAsync(
@@ -74,7 +72,7 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.id.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        return doRequestAsync(via)
     }
 
     override suspend fun sendAsync(
@@ -82,6 +80,6 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.id.toJsonElement()
-        return via.makeRequestAsync(method, parameters, returnType, multipartData)
+        return doRequestAsync(via)
     }
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/MediaAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/MediaAction.kt
@@ -8,6 +8,9 @@ import eu.vendeli.tgbot.utils.makeRequestAsync
 import eu.vendeli.tgbot.utils.makeSilentRequest
 import eu.vendeli.tgbot.utils.toJsonElement
 import kotlinx.coroutines.Deferred
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.JsonUnquotedLiteral
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.collections.set
 
 /**
@@ -29,21 +32,25 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
      */
     override suspend fun send(to: String, via: TelegramBot) {
         parameters[idRefField] = to.toJsonElement()
+        handleParseModeInMultipart()
         via.makeSilentRequest(method, parameters, multipartData)
     }
 
     override suspend fun send(to: Long, via: TelegramBot) {
         parameters[idRefField] = to.toJsonElement()
+        handleParseModeInMultipart()
         via.makeSilentRequest(method, parameters, multipartData)
     }
 
     override suspend fun send(to: User, via: TelegramBot) {
         parameters[idRefField] = to.id.toJsonElement()
+        handleParseModeInMultipart()
         via.makeSilentRequest(method, parameters, multipartData)
     }
 
     override suspend fun send(to: Chat, via: TelegramBot) {
         parameters[idRefField] = to.id.toJsonElement()
+        handleParseModeInMultipart()
         via.makeSilentRequest(method, parameters, multipartData)
     }
 
@@ -58,6 +65,7 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.toJsonElement()
+        handleParseModeInMultipart()
         return via.makeRequestAsync(method, parameters, returnType, multipartData)
     }
 
@@ -66,6 +74,7 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.toJsonElement()
+        handleParseModeInMultipart()
         return via.makeRequestAsync(method, parameters, returnType, multipartData)
     }
 
@@ -74,6 +83,7 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.id.toJsonElement()
+        handleParseModeInMultipart()
         return via.makeRequestAsync(method, parameters, returnType, multipartData)
     }
 
@@ -82,6 +92,14 @@ abstract class MediaAction<ReturnType> : Action<ReturnType>() {
         via: TelegramBot,
     ): Deferred<Response<out ReturnType>> {
         parameters[idRefField] = to.id.toJsonElement()
+        handleParseModeInMultipart()
         return via.makeRequestAsync(method, parameters, returnType, multipartData)
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private fun handleParseModeInMultipart() {
+        if (multipartData.isNotEmpty()) parameters["parse_mode"]?.let {
+            parameters["parse_mode"] = JsonUnquotedLiteral(it.jsonPrimitive.content)
+        }
     }
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/Request.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/Request.kt
@@ -1,0 +1,12 @@
+package eu.vendeli.tgbot.interfaces
+
+import eu.vendeli.tgbot.TelegramBot
+import eu.vendeli.tgbot.types.internal.Response
+import kotlinx.coroutines.Deferred
+import kotlinx.serialization.json.JsonElement
+
+interface Request<ReturnType> {
+    fun Request<ReturnType>.getParameters(): MutableMap<String, JsonElement> = TODO()
+    suspend fun Request<ReturnType>.doRequest(bot: TelegramBot): Unit = TODO()
+    suspend fun Request<ReturnType>.doRequestAsync(bot: TelegramBot): Deferred<Response<out ReturnType>> = TODO()
+}

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/TgAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/TgAction.kt
@@ -1,7 +1,10 @@
 package eu.vendeli.tgbot.interfaces
 
+import eu.vendeli.tgbot.TelegramBot
 import eu.vendeli.tgbot.types.internal.TgMethod
 import eu.vendeli.tgbot.types.internal.options.Options
+import eu.vendeli.tgbot.utils.makeRequestAsync
+import eu.vendeli.tgbot.utils.makeSilentRequest
 import io.ktor.http.content.PartData
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.JsonElement
@@ -10,7 +13,7 @@ import kotlin.properties.Delegates
 /**
  * Tg action, see [Actions article](https://github.com/vendelieu/telegram-bot/wiki/Actions)
  */
-abstract class TgAction<ReturnType> {
+abstract class TgAction<ReturnType> : Request<ReturnType> {
     /**
      * A method that is implemented in Action.
      */
@@ -35,4 +38,11 @@ abstract class TgAction<ReturnType> {
      * Multipart payload of request.
      */
     internal val multipartData: MutableList<PartData.BinaryItem> = mutableListOf()
+
+    override suspend fun Request<ReturnType>.doRequest(bot: TelegramBot) {
+        bot.makeSilentRequest(method, parameters, multipartData)
+    }
+
+    override suspend fun Request<ReturnType>.doRequestAsync(bot: TelegramBot) =
+        bot.makeRequestAsync(method, parameters, returnType, multipartData)
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Birthdate.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Birthdate.kt
@@ -1,0 +1,10 @@
+package eu.vendeli.tgbot.types
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Birthdate(
+    val day: Int,
+    val month: Int,
+    val year: Int? = null,
+)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Birthdate.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Birthdate.kt
@@ -2,6 +2,14 @@ package eu.vendeli.tgbot.types
 
 import kotlinx.serialization.Serializable
 
+/**
+
+ *
+ * Api reference: https://core.telegram.org/bots/api#birthdate
+ * @property day Day of the user's birth; 1-31
+ * @property month Month of the user's birth; 1-12
+ * @property year Optional. Year of the user's birth
+ */
 @Serializable
 data class Birthdate(
     val day: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/CallbackQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/CallbackQuery.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents an incoming callback query from a callback button in an inline keyboard. If the button that originated the query was attached to a message sent by the bot, the field message will be present. If the button was attached to a message sent via the bot (in inline mode), the field inline_message_id will be present. Exactly one of the fields data or game_short_name will be present.
+ *
  * Api reference: https://core.telegram.org/bots/api#callbackquery
  * @property id Unique identifier for this query
  * @property from Sender
@@ -12,7 +13,7 @@ import kotlinx.serialization.Serializable
  * @property chatInstance Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent. Useful for high scores in games.
  * @property data Optional. Data associated with the callback button. Be aware that the message originated the query can contain no callback buttons with this data.
  * @property gameShortName Optional. Short name of a Game to be returned, serves as the unique identifier for the game
-*/
+ */
 @Serializable
 data class CallbackQuery(
     val id: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Contact.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Contact.kt
@@ -4,13 +4,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a phone contact.
+ *
  * Api reference: https://core.telegram.org/bots/api#contact
  * @property phoneNumber Contact's phone number
  * @property firstName Contact's first name
  * @property lastName Optional. Contact's last name
  * @property userId Optional. Contact's user identifier in Telegram. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
  * @property vcard Optional. Additional data about the contact in the form of a vCard
-*/
+ */
 @Serializable
 data class Contact(
     val phoneNumber: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ExternalReplyInfo.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ExternalReplyInfo.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains information about a message that is being replied to, which may come from another chat or forum topic.
+ *
  * Api reference: https://core.telegram.org/bots/api#externalreplyinfo
  * @property origin Origin of the message replied to by the given message
  * @property chat Optional. Chat the original message belongs to. Available only if the chat is a supergroup or a channel.
@@ -41,7 +42,7 @@ import kotlinx.serialization.Serializable
  * @property location Optional. Message is a shared location, information about the location
  * @property poll Optional. Message is a native poll, information about the poll
  * @property venue Optional. Message is a venue, information about the venue
-*/
+ */
 @Serializable
 data class ExternalReplyInfo(
     val origin: MessageOrigin,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Giveaway.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Giveaway.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a message about a scheduled giveaway.
+ *
  * Api reference: https://core.telegram.org/bots/api#giveaway
  * @property chats The list of chats which the user must join to participate in the giveaway
  * @property winnersSelectionDate Point in time (Unix timestamp) when winners of the giveaway will be selected
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property prizeDescription Optional. Description of additional giveaway prize
  * @property countryCodes Optional. A list of two-letter ISO 3166-1 alpha-2 country codes indicating the countries from which eligible users for the giveaway must come. If empty, then all users can participate in the giveaway. Users with a phone number that was bought on Fragment can always participate in giveaways.
  * @property premiumSubscriptionMonthCount Optional. The number of months the Telegram Premium subscription won from the giveaway will be active for
-*/
+ */
 @Serializable
 data class Giveaway(
     val chats: List<Chat>,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/GiveawayCompleted.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/GiveawayCompleted.kt
@@ -4,11 +4,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about the completion of a giveaway without public winners.
+ *
  * Api reference: https://core.telegram.org/bots/api#giveawaycompleted
  * @property winnerCount Number of winners in the giveaway
  * @property unclaimedPrizeCount Optional. Number of undistributed prizes
  * @property giveawayMessage Optional. Message with the giveaway that was completed, if it wasn't deleted
-*/
+ */
 @Serializable
 data class GiveawayCompleted(
     val winnerCount: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/GiveawayWinners.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/GiveawayWinners.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a message about the completion of a giveaway with public winners.
+ *
  * Api reference: https://core.telegram.org/bots/api#giveawaywinners
  * @property chat The chat that created the giveaway
  * @property giveawayMessageId Identifier of the message with the giveaway in the chat
@@ -17,7 +18,7 @@ import kotlinx.serialization.Serializable
  * @property onlyNewMembers Optional. True, if only users who had joined the chats after the giveaway started were eligible to win
  * @property wasRefunded Optional. True, if the giveaway was canceled because the payment for it was refunded
  * @property prizeDescription Optional. Description of additional giveaway prize
-*/
+ */
 @Serializable
 data class GiveawayWinners(
     val chat: Chat,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/LinkPreviewOptions.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/LinkPreviewOptions.kt
@@ -4,13 +4,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes the options used for link preview generation.
+ *
  * Api reference: https://core.telegram.org/bots/api#linkpreviewoptions
  * @property isDisabled Optional. True, if the link preview is disabled
  * @property url Optional. URL to use for the link preview. If empty, then the first URL found in the message text will be used
  * @property preferSmallMedia Optional. True, if the media in the link preview is supposed to be shrunk; ignored if the URL isn't explicitly specified or media size change isn't supported for the preview
  * @property preferLargeMedia Optional. True, if the media in the link preview is supposed to be enlarged; ignored if the URL isn't explicitly specified or media size change isn't supported for the preview
  * @property showAboveText Optional. True, if the link preview must be shown above the message text; otherwise, the link preview will be shown below the message text
-*/
+ */
 @Serializable
 data class LinkPreviewOptions(
     var isDisabled: Boolean? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Location.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Location.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a point on the map.
+ *
  * Api reference: https://core.telegram.org/bots/api#location
  * @property latitude Latitude as defined by sender
  * @property longitude Longitude as defined by sender
@@ -11,7 +12,7 @@ import kotlinx.serialization.Serializable
  * @property livePeriod Optional. Time relative to the message sending date, during which the location can be updated; in seconds. For active live locations only.
  * @property heading Optional. The direction in which user is moving, in degrees; 1-360. For active live locations only.
  * @property proximityAlertRadius Optional. The maximum distance for proximity alerts about approaching another chat member, in meters. For sent live locations only.
-*/
+ */
 @Serializable
 data class Location(
     val longitude: Float,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MaybeInaccessibleMessage.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MaybeInaccessibleMessage.kt
@@ -14,9 +14,10 @@ import kotlinx.serialization.json.longOrNull
  * This object describes a message that can be inaccessible to the bot. It can be one of
  * - Message
  * - InaccessibleMessage
+ *
  * Api reference: https://core.telegram.org/bots/api#maybeinaccessiblemessage
  *
-*/
+ */
 @Serializable(MaybeInaccessibleMessage.Companion::class)
 sealed class MaybeInaccessibleMessage {
     abstract val chat: Chat

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Message.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Message.kt
@@ -122,8 +122,10 @@ data class Message(
     val from: User? = null,
     val senderChat: Chat? = null,
     val senderBoostCount: Int? = null,
+    val senderBusinessBot: User? = null,
     @Serializable(InstantSerializer::class)
     override val date: Instant,
+    val businessConnectionId: String? = null,
     override val chat: Chat,
     val forwardOrigin: MessageOrigin? = null,
     val isTopicMessage: Boolean? = null,
@@ -136,6 +138,7 @@ data class Message(
     @Serializable(InstantSerializer::class)
     val editDate: Instant? = null,
     val hasProtectedContent: Boolean? = null,
+    val isFromOffline: Boolean? = null,
     val mediaGroupId: String? = null,
     val authorSignature: String? = null,
     val text: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Message.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Message.kt
@@ -36,13 +36,16 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a message.
+ *
  * Api reference: https://core.telegram.org/bots/api#message
  * @property messageId Unique message identifier inside this chat
  * @property messageThreadId Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
  * @property from Optional. Sender of the message; empty for messages sent to channels. For backward compatibility, the field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
  * @property senderChat Optional. Sender of the message, sent on behalf of a chat. For example, the channel itself for channel posts, the supergroup itself for messages from anonymous group administrators, the linked channel for messages automatically forwarded to the discussion group. For backward compatibility, the field from contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
  * @property senderBoostCount Optional. If the sender of the message boosted the chat, the number of boosts added by the user
+ * @property senderBusinessBot Optional. The bot that actually sent the message on behalf of the business account. Available only for outgoing messages sent on behalf of the connected business account.
  * @property date Date the message was sent in Unix time. It is always a positive number, representing a valid date.
+ * @property businessConnectionId Optional. Unique identifier of the business connection from which the message was received. If non-empty, the message belongs to a chat of the corresponding business account that is independent from any potential bot chat which might share the same identifier.
  * @property chat Chat the message belongs to
  * @property forwardOrigin Optional. Information about the original message for forwarded messages
  * @property isTopicMessage Optional. True, if the message is sent to a forum topic
@@ -54,6 +57,7 @@ import kotlinx.serialization.Serializable
  * @property viaBot Optional. Bot through which the message was sent
  * @property editDate Optional. Date the message was last edited in Unix time
  * @property hasProtectedContent Optional. True, if the message can't be forwarded
+ * @property isFromOffline Optional. True, if the message was sent by an implicit action, for example, as an away or a greeting business message, or as a scheduled message
  * @property mediaGroupId Optional. The unique identifier of a media message group this message belongs to
  * @property authorSignature Optional. Signature of the post author for messages in channels, or the custom title of an anonymous group administrator
  * @property text Optional. For text messages, the actual UTF-8 text of the message
@@ -114,7 +118,7 @@ import kotlinx.serialization.Serializable
  * @property videoChatParticipantsInvited Optional. Service message: new participants invited to a video chat
  * @property webAppData Optional. Service message: data sent by a Web App
  * @property replyMarkup Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
-*/
+ */
 @Serializable
 data class Message(
     override val messageId: Long,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageAutoDeleteTimerChanged.kt
@@ -4,9 +4,10 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about a change in auto-delete timer settings.
+ *
  * Api reference: https://core.telegram.org/bots/api#messageautodeletetimerchanged
  * @property messageAutoDeleteTime New auto-delete time for messages in the chat; in seconds
-*/
+ */
 @Serializable
 data class MessageAutoDeleteTimerChanged(
     val messageAutoDeleteTime: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageEntity.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageEntity.kt
@@ -62,6 +62,7 @@ enum class EntityType {
 
 /**
  * This object represents one special entity in a text message. For example, hashtags, usernames, URLs, etc.
+ *
  * Api reference: https://core.telegram.org/bots/api#messageentity
  * @property type Type of the entity. Currently, can be "mention" (@username), "hashtag" (#hashtag), "cashtag" ($USD), "bot_command" (/start@jobs_bot), "url" (https://telegram.org), "email" (do-not-reply@telegram.org), "phone_number" (+1-212-555-0123), "bold" (bold text), "italic" (italic text), "underline" (underlined text), "strikethrough" (strikethrough text), "spoiler" (spoiler message), "blockquote" (block quotation), "code" (monowidth string), "pre" (monowidth block), "text_link" (for clickable text URLs), "text_mention" (for users without usernames), "custom_emoji" (for inline custom emoji stickers)
  * @property offset Offset in UTF-16 code units to the start of the entity
@@ -70,7 +71,7 @@ enum class EntityType {
  * @property user Optional. For "text_mention" only, the mentioned user
  * @property language Optional. For "pre" only, the programming language of the entity text
  * @property customEmojiId Optional. For "custom_emoji" only, unique identifier of the custom emoji. Use getCustomEmojiStickers to get full information about the sticker
-*/
+ */
 @Serializable
 data class MessageEntity(
     val type: EntityType,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageId.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageId.kt
@@ -5,8 +5,9 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a unique message identifier.
+ *
  * Api reference: https://core.telegram.org/bots/api#messageid
  * @property messageId Unique message identifier
-*/
+ */
 @Serializable
 data class MessageId(val messageId: Long) : MultipleResponse

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageOrigin.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageOrigin.kt
@@ -12,9 +12,10 @@ import kotlinx.serialization.Serializable
  * - MessageOriginHiddenUser
  * - MessageOriginChat
  * - MessageOriginChannel
+ *
  * Api reference: https://core.telegram.org/bots/api#messageorigin
  *
-*/
+ */
 @Serializable
 sealed class MessageOrigin(val type: String) {
     @Serializable(InstantSerializer::class)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageReactionCountUpdated.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageReactionCountUpdated.kt
@@ -7,12 +7,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents reaction changes on a message with anonymous reactions.
+ *
  * Api reference: https://core.telegram.org/bots/api#messagereactioncountupdated
  * @property chat The chat containing the message
  * @property messageId Unique message identifier inside the chat
  * @property date Date of the change in Unix time
  * @property reactions List of reactions that are present on the message
-*/
+ */
 @Serializable
 data class MessageReactionCountUpdated(
     val chat: Chat,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageReactionUpdated.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/MessageReactionUpdated.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a change of a reaction on a message performed by a user.
+ *
  * Api reference: https://core.telegram.org/bots/api#messagereactionupdated
  * @property chat The chat containing the message the user reacted to
  * @property messageId Unique identifier of the message inside the chat
@@ -15,7 +16,7 @@ import kotlinx.serialization.Serializable
  * @property date Date of the change in Unix time
  * @property oldReaction Previous list of reaction types that were set by the user
  * @property newReaction New list of reaction types that have been set by the user
-*/
+ */
 @Serializable
 data class MessageReactionUpdated(
     val chat: Chat,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Poll.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Poll.kt
@@ -16,6 +16,7 @@ enum class PollType {
 
 /**
  * This object contains information about a poll.
+ *
  * Api reference: https://core.telegram.org/bots/api#poll
  * @property id Unique poll identifier
  * @property question Poll question, 1-300 characters
@@ -30,7 +31,7 @@ enum class PollType {
  * @property explanationEntities Optional. Special entities like usernames, URLs, bot commands, etc. that appear in the explanation
  * @property openPeriod Optional. Amount of time in seconds the poll will be active after creation
  * @property closeDate Optional. Point in time (Unix timestamp) when the poll will be automatically closed
-*/
+ */
 @Serializable
 data class Poll(
     val id: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/PollAnswer.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/PollAnswer.kt
@@ -5,12 +5,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents an answer of a user in a non-anonymous poll.
+ *
  * Api reference: https://core.telegram.org/bots/api#pollanswer
  * @property pollId Unique poll identifier
  * @property voterChat Optional. The chat that changed the answer to the poll, if the voter is anonymous
  * @property user Optional. The user that changed the answer to the poll, if the voter isn't anonymous
  * @property optionIds 0-based identifiers of chosen answer options. May be empty if the vote was retracted.
-*/
+ */
 @Serializable
 data class PollAnswer(
     val pollId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/PollOption.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/PollOption.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains information about one answer option in a poll.
+ *
  * Api reference: https://core.telegram.org/bots/api#polloption
  * @property text Option text, 1-100 characters
  * @property voterCount Number of users that voted for this option
-*/
+ */
 @Serializable
 data class PollOption(
     val text: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ProximityAlertTriggered.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ProximityAlertTriggered.kt
@@ -4,11 +4,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents the content of a service message, sent whenever a user in the chat triggers a proximity alert set by another user.
+ *
  * Api reference: https://core.telegram.org/bots/api#proximityalerttriggered
  * @property traveler User that triggered the alert
  * @property watcher User that set the alert
  * @property distance The distance between the users
-*/
+ */
 @Serializable
 data class ProximityAlertTriggered(
     val traveler: User,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ReactionCount.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ReactionCount.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * Represents a reaction added to a message along with the number of times it was added.
+ *
  * Api reference: https://core.telegram.org/bots/api#reactioncount
  * @property type Type of the reaction
  * @property totalCount Number of times the reaction was added
-*/
+ */
 @Serializable
 data class ReactionCount(
     val type: ReactionType,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ReactionType.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ReactionType.kt
@@ -229,9 +229,10 @@ enum class EmojiType(val literal: String) {
  * This object describes the type of a reaction. Currently, it can be one of
  * - ReactionTypeEmoji
  * - ReactionTypeCustomEmoji
+ *
  * Api reference: https://core.telegram.org/bots/api#reactiontype
  *
-*/
+ */
 @Serializable
 sealed class ReactionType(
     val type: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ReplyParameters.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ReplyParameters.kt
@@ -5,15 +5,16 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes reply parameters for the message that is being sent.
+ *
  * Api reference: https://core.telegram.org/bots/api#replyparameters
  * @property messageId Identifier of the message that will be replied to in the current chat, or in the chat chat_id if it is specified
- * @property chatId Optional. If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format @channelusername)
- * @property allowSendingWithoutReply Optional. Pass True if the message should be sent even if the specified message to be replied to is not found; can be used only for replies in the same chat and forum topic.
+ * @property chatId Optional. If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format @channelusername). Not supported for messages sent on behalf of a business account.
+ * @property allowSendingWithoutReply Optional. Pass True if the message should be sent even if the specified message to be replied to is not found. Always False for replies in another chat or forum topic. Always True for messages sent on behalf of a business account.
  * @property quote Optional. Quoted part of the message to be replied to; 0-1024 characters after entities parsing. The quote must be an exact substring of the message to be replied to, including bold, italic, underline, strikethrough, spoiler, and custom_emoji entities. The message will fail to send if the quote isn't found in the original message.
  * @property quoteParseMode Optional. Mode for parsing entities in the quote. See formatting options for more details.
  * @property quoteEntities Optional. A JSON-serialized list of special entities that appear in the quote. It can be specified instead of quote_parse_mode.
  * @property quotePosition Optional. Position of the quote in the original message in UTF-16 code units
-*/
+ */
 @Serializable
 data class ReplyParameters(
     var messageId: Long,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ResponseParameters.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/ResponseParameters.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes why a request was unsuccessful.
+ *
  * Api reference: https://core.telegram.org/bots/api#responseparameters
  * @property migrateToChatId Optional. The group has been migrated to a supergroup with the specified identifier. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this identifier.
  * @property retryAfter Optional. In case of exceeding flood control, the number of seconds left to wait before the request can be repeated
-*/
+ */
 @Serializable
 data class ResponseParameters(
     val migrateToChatId: Long? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/SentWebAppMessage.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/SentWebAppMessage.kt
@@ -4,8 +4,9 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes an inline message sent by a Web App on behalf of a user.
+ *
  * Api reference: https://core.telegram.org/bots/api#sentwebappmessage
  * @property inlineMessageId Optional. Identifier of the sent inline message. Available only if there is an inline keyboard attached to the message.
-*/
+ */
 @Serializable
 data class SentWebAppMessage(val inlineMessageId: String? = null)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/SharedUser.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/SharedUser.kt
@@ -3,6 +3,16 @@ package eu.vendeli.tgbot.types
 import eu.vendeli.tgbot.types.media.PhotoSize
 import kotlinx.serialization.Serializable
 
+/**
+ * This object contains information about a user that was shared with the bot using a KeyboardButtonRequestUser button.
+ *
+ * Api reference: https://core.telegram.org/bots/api#shareduser
+ * @property userId Identifier of the shared user. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so 64-bit integers or double-precision float types are safe for storing these identifiers. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means.
+ * @property firstName Optional. First name of the user, if the name was requested by the bot
+ * @property lastName Optional. Last name of the user, if the name was requested by the bot
+ * @property username Optional. Username of the user, if the username was requested by the bot
+ * @property photo Optional. Available sizes of the chat photo, if the photo was requested by the bot
+ */
 @Serializable
 data class SharedUser(
     val userId: Long,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/SharedUser.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/SharedUser.kt
@@ -1,0 +1,13 @@
+package eu.vendeli.tgbot.types
+
+import eu.vendeli.tgbot.types.media.PhotoSize
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SharedUser(
+    val userId: Long,
+    val firstName: String? = null,
+    val lastName: String? = null,
+    val username: String? = null,
+    val photo: List<PhotoSize>? = null
+)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/SharedUser.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/SharedUser.kt
@@ -9,5 +9,5 @@ data class SharedUser(
     val firstName: String? = null,
     val lastName: String? = null,
     val username: String? = null,
-    val photo: List<PhotoSize>? = null
+    val photo: List<PhotoSize>? = null,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/TextQuote.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/TextQuote.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains information about the quoted part of a message that is replied to by the given message.
+ *
  * Api reference: https://core.telegram.org/bots/api#textquote
  * @property text Text of the quoted part of a message that is replied to by the given message
  * @property entities Optional. Special entities that appear in the quote. Currently, only bold, italic, underline, strikethrough, spoiler, and custom_emoji entities are kept in quotes.
  * @property position Approximate quote position in the original message in UTF-16 code units as specified by the sender
  * @property isManual Optional. True, if the quote was chosen manually by the message sender. Otherwise, the quote was added automatically by the server.
-*/
+ */
 @Serializable
 data class TextQuote(
     val text: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Update.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Update.kt
@@ -16,12 +16,17 @@ import kotlinx.serialization.Serializable
 /**
  * This object represents an incoming update.
  * At most one of the optional parameters can be present in any given update.
+ *
  * Api reference: https://core.telegram.org/bots/api#update
  * @property updateId The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially. This identifier becomes especially handy if you're using webhooks, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates for at least a week, then identifier of the next update will be chosen randomly instead of sequentially.
  * @property message Optional. New incoming message of any kind - text, photo, sticker, etc.
  * @property editedMessage Optional. New version of a message that is known to the bot and was edited. This update may at times be triggered by changes to message fields that are either unavailable or not actively used by your bot.
  * @property channelPost Optional. New incoming channel post of any kind - text, photo, sticker, etc.
  * @property editedChannelPost Optional. New version of a channel post that is known to the bot and was edited. This update may at times be triggered by changes to message fields that are either unavailable or not actively used by your bot.
+ * @property businessConnection Optional. The bot was connected to or disconnected from a business account, or a user edited an existing connection with the bot
+ * @property businessMessage Optional. New non-service message from a connected business account
+ * @property editedBusinessMessage Optional. New version of a message from a connected business account
+ * @property deletedBusinessMessages Optional. Messages were deleted from a connected business account
  * @property messageReaction Optional. A reaction to a message was changed by a user. The bot must be an administrator in the chat and must explicitly specify "message_reaction" in the list of allowed_updates to receive these updates. The update isn't received for reactions set by bots.
  * @property messageReactionCount Optional. Reactions to a message with anonymous reactions were changed. The bot must be an administrator in the chat and must explicitly specify "message_reaction_count" in the list of allowed_updates to receive these updates. The updates are grouped and can be sent with delay up to a few minutes.
  * @property inlineQuery Optional. New incoming inline query

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Update.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Update.kt
@@ -3,6 +3,8 @@ package eu.vendeli.tgbot.types
 import eu.vendeli.tgbot.interfaces.MultipleResponse
 import eu.vendeli.tgbot.types.boost.ChatBoostRemoved
 import eu.vendeli.tgbot.types.boost.ChatBoostUpdated
+import eu.vendeli.tgbot.types.business.BusinessConnection
+import eu.vendeli.tgbot.types.business.BusinessMessagesDeleted
 import eu.vendeli.tgbot.types.chat.ChatJoinRequest
 import eu.vendeli.tgbot.types.chat.ChatMemberUpdated
 import eu.vendeli.tgbot.types.inline.ChosenInlineResult
@@ -34,7 +36,7 @@ import kotlinx.serialization.Serializable
  * @property chatJoinRequest Optional. A request to join the chat has been sent. The bot must have the can_invite_users administrator right in the chat to receive these updates.
  * @property chatBoost Optional. A chat boost was added or changed. The bot must be an administrator in the chat to receive these updates.
  * @property removedChatBoost Optional. A boost was removed from a chat. The bot must be an administrator in the chat to receive these updates.
-*/
+ */
 @Serializable
 data class Update(
     val updateId: Int,
@@ -42,6 +44,10 @@ data class Update(
     val editedMessage: Message? = null,
     val channelPost: Message? = null,
     val editedChannelPost: Message? = null,
+    val businessConnection: BusinessConnection? = null,
+    val businessMessage: Message? = null,
+    val editedBusinessMessage: Message? = null,
+    val deletedBusinessMessages: BusinessMessagesDeleted? = null,
     val messageReaction: MessageReactionUpdated? = null,
     val messageReactionCount: MessageReactionCountUpdated? = null,
     val inlineQuery: InlineQuery? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/User.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/User.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a Telegram user or bot.
+ *
  * Api reference: https://core.telegram.org/bots/api#user
  * @property id Unique identifier for this user or bot. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
  * @property isBot True, if this user is a bot
@@ -16,7 +17,8 @@ import kotlinx.serialization.Serializable
  * @property canJoinGroups Optional. True, if the bot can be invited to groups. Returned only in getMe.
  * @property canReadAllGroupMessages Optional. True, if privacy mode is disabled for the bot. Returned only in getMe.
  * @property supportsInlineQueries Optional. True, if the bot supports inline queries. Returned only in getMe.
-*/
+ * @property canConnectToBusiness Optional. True, if the bot can be connected to a Telegram Business account to receive its messages. Returned only in getMe.
+ */
 @Serializable
 data class User(
     val id: Long,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/User.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/User.kt
@@ -30,4 +30,5 @@ data class User(
     val canJoinGroups: Boolean? = null,
     val canReadAllGroupMessages: Boolean? = null,
     val supportsInlineQueries: Boolean? = null,
+    val canConnectToBusiness: Boolean? = null,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/UserProfilePhotos.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/UserProfilePhotos.kt
@@ -5,10 +5,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represent a user's profile pictures.
+ *
  * Api reference: https://core.telegram.org/bots/api#userprofilephotos
  * @property totalCount Total number of profile pictures the target user has
  * @property photos Requested profile pictures (in up to 4 sizes each)
-*/
+ */
 @Serializable
 data class UserProfilePhotos(
     val totalCount: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/UsersShared.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/UsersShared.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains information about the users whose identifiers were shared with the bot using a KeyboardButtonRequestUsers button.
+ *
  * Api reference: https://core.telegram.org/bots/api#usersshared
  * @property requestId Identifier of the request
- * @property userIds Identifiers of the shared users. These numbers may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting them. But they have at most 52 significant bits, so 64-bit integers or double-precision float types are safe for storing these identifiers. The bot may not have access to the users and could be unable to use these identifiers, unless the users are already known to the bot by some other means.
-*/
+ * @property users Information about users shared with the bot.
+ */
 @Serializable
 data class UsersShared(
     val requestId: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/UsersShared.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/UsersShared.kt
@@ -11,5 +11,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UsersShared(
     val requestId: Int,
-    val userId: List<Long>,
+    val users: List<SharedUser>,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Venue.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/Venue.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a venue.
+ *
  * Api reference: https://core.telegram.org/bots/api#venue
  * @property location Venue location. Can't be a live location
  * @property title Name of the venue
@@ -12,7 +13,7 @@ import kotlinx.serialization.Serializable
  * @property foursquareType Optional. Foursquare type of the venue. (For example, "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".)
  * @property googlePlaceId Optional. Google Places identifier of the venue
  * @property googlePlaceType Optional. Google Places type of the venue. (See supported types.)
-*/
+ */
 @Serializable
 data class Venue(
     val location: LocationContent,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/WebhookInfo.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/WebhookInfo.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes the current status of a webhook.
+ *
  * Api reference: https://core.telegram.org/bots/api#webhookinfo
  * @property url Webhook URL, may be empty if webhook is not set up
  * @property hasCustomCertificate True, if a custom certificate was provided for webhook certificate checks
@@ -17,7 +18,7 @@ import kotlinx.serialization.Serializable
  * @property lastSynchronizationErrorDate Optional. Unix time of the most recent error that happened when trying to synchronize available updates with Telegram datacenters
  * @property maxConnections Optional. The maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
  * @property allowedUpdates Optional. A list of update types the bot is subscribed to. Defaults to all update types except chat_member
-*/
+ */
 @Serializable
 data class WebhookInfo(
     val url: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/WriteAccessAllowed.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/WriteAccessAllowed.kt
@@ -4,11 +4,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about a user allowing a bot to write messages after adding it to the attachment menu, launching a Web App from a link, or accepting an explicit request from a Web App sent by the method requestWriteAccess.
+ *
  * Api reference: https://core.telegram.org/bots/api#writeaccessallowed
  * @property fromRequest Optional. True, if the access was granted after the user accepted an explicit request from a Web App sent by the method requestWriteAccess
  * @property webAppName Optional. Name of the Web App, if the access was granted when the Web App was launched from a link
  * @property fromAttachmentMenu Optional. True, if the access was granted when the bot was added to the attachment or side menu
-*/
+ */
 @Serializable
 data class WriteAccessAllowed(
     val fromRequest: Boolean? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/ChatBoost.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/ChatBoost.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains information about a chat boost.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatboost
  * @property boostId Unique identifier of the boost
  * @property addDate Point in time (Unix timestamp) when the chat was boosted
  * @property expirationDate Point in time (Unix timestamp) when the boost will automatically expire, unless the booster's Telegram Premium subscription is prolonged
  * @property source Source of the added boost
-*/
+ */
 @Serializable
 data class ChatBoost(
     val boostId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/ChatBoostAdded.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/ChatBoostAdded.kt
@@ -4,9 +4,10 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about a user boosting a chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatboostadded
  * @property boostCount Number of boosts added by the user
-*/
+ */
 @Serializable
 data class ChatBoostAdded(
     val boostCount: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/ChatBoostRemoved.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/ChatBoostRemoved.kt
@@ -7,12 +7,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a boost removed from a chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatboostremoved
  * @property chat Chat which was boosted
  * @property boostId Unique identifier of the boost
  * @property removeDate Point in time (Unix timestamp) when the boost was removed
  * @property source Source of the removed boost
-*/
+ */
 @Serializable
 data class ChatBoostRemoved(
     val chat: Chat,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/ChatBoostUpdated.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/ChatBoostUpdated.kt
@@ -5,10 +5,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a boost added to a chat or changed.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatboostupdated
  * @property chat Chat which was boosted
  * @property boost Information about the chat boost
-*/
+ */
 @Serializable
 data class ChatBoostUpdated(
     val chat: Chat,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/UserChatBoosts.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/boost/UserChatBoosts.kt
@@ -4,9 +4,10 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a list of boosts added to a chat by a user.
+ *
  * Api reference: https://core.telegram.org/bots/api#userchatboosts
  * @property boosts The list of boosts added to the chat by the user
-*/
+ */
 @Serializable
 data class UserChatBoosts(
     val boosts: List<ChatBoost>,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotCommand.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotCommand.kt
@@ -5,10 +5,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a bot command.
+ *
  * Api reference: https://core.telegram.org/bots/api#botcommand
  * @property command Text of the command; 1-32 characters. Can contain only lowercase English letters, digits and underscores.
  * @property description Description of the command; 1-256 characters.
-*/
+ */
 @Serializable
 data class BotCommand(
     val command: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotCommandScope.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotCommandScope.kt
@@ -12,9 +12,10 @@ import kotlinx.serialization.Serializable
  * - BotCommandScopeChat
  * - BotCommandScopeChatAdministrators
  * - BotCommandScopeChatMember
+ *
  * Api reference: https://core.telegram.org/bots/api#botcommandscope
  *
-*/
+ */
 @Serializable
 sealed class BotCommandScope(val type: String) {
     @Serializable

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotDescription.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotDescription.kt
@@ -4,8 +4,9 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents the bot's description.
+ *
  * Api reference: https://core.telegram.org/bots/api#botdescription
  * @property description The bot's description
-*/
+ */
 @Serializable
 data class BotDescription(val description: String)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotName.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotName.kt
@@ -4,8 +4,9 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents the bot's name.
+ *
  * Api reference: https://core.telegram.org/bots/api#botname
  * @property name The bot's name
-*/
+ */
 @Serializable
 data class BotName(val name: String)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotShortDescription.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/bot/BotShortDescription.kt
@@ -4,8 +4,9 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents the bot's short description.
+ *
  * Api reference: https://core.telegram.org/bots/api#botshortdescription
  * @property shortDescription The bot's short description
-*/
+ */
 @Serializable
 data class BotShortDescription(val shortDescription: String)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessConnection.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessConnection.kt
@@ -3,6 +3,17 @@ package eu.vendeli.tgbot.types.business
 import eu.vendeli.tgbot.types.User
 import kotlinx.serialization.Serializable
 
+/**
+ * Describes the connection of the bot with a business account.
+ *
+ * Api reference: https://core.telegram.org/bots/api#businessconnection
+ * @property id Unique identifier of the business connection
+ * @property user Business account user that created the business connection
+ * @property userChatId Identifier of a private chat with the user who created the business connection. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
+ * @property date Date the connection was established in Unix time
+ * @property canReply True, if the bot can act on behalf of the business account in chats that were active in the last 24 hours
+ * @property isEnabled True, if the connection is active
+ */
 @Serializable
 data class BusinessConnection(
     val id: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessConnection.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessConnection.kt
@@ -1,0 +1,14 @@
+package eu.vendeli.tgbot.types.business
+
+import eu.vendeli.tgbot.types.User
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BusinessConnection(
+    val id: String,
+    val user: User,
+    val userChatId: Long,
+    val date: Long,
+    val canReply: Boolean,
+    val isEnabled: Boolean,
+)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessIntro.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessIntro.kt
@@ -3,6 +3,14 @@ package eu.vendeli.tgbot.types.business
 import eu.vendeli.tgbot.types.media.Sticker
 import kotlinx.serialization.Serializable
 
+/**
+
+ *
+ * Api reference: https://core.telegram.org/bots/api#businessintro
+ * @property title Optional. Title text of the business intro
+ * @property message Optional. Message text of the business intro
+ * @property sticker Optional. Sticker of the business intro
+ */
 @Serializable
 data class BusinessIntro(
     val title: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessIntro.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessIntro.kt
@@ -1,0 +1,11 @@
+package eu.vendeli.tgbot.types.business
+
+import eu.vendeli.tgbot.types.media.Sticker
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BusinessIntro(
+    val title: String? = null,
+    val message: String? = null,
+    val sticker: Sticker? = null,
+)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessLocation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessLocation.kt
@@ -1,0 +1,10 @@
+package eu.vendeli.tgbot.types.business
+
+import eu.vendeli.tgbot.types.Location
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BusinessLocation(
+    val address: String,
+    val location: Location? = null,
+)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessLocation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessLocation.kt
@@ -3,6 +3,13 @@ package eu.vendeli.tgbot.types.business
 import eu.vendeli.tgbot.types.Location
 import kotlinx.serialization.Serializable
 
+/**
+
+ *
+ * Api reference: https://core.telegram.org/bots/api#businesslocation
+ * @property address Address of the business
+ * @property location Optional. Location of the business
+ */
 @Serializable
 data class BusinessLocation(
     val address: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessMessagesDeleted.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessMessagesDeleted.kt
@@ -1,0 +1,11 @@
+package eu.vendeli.tgbot.types.business
+
+import eu.vendeli.tgbot.types.chat.Chat
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BusinessMessagesDeleted(
+    val businessConnectionId: String,
+    val chat: Chat,
+    val messageIds: List<Int>
+)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessMessagesDeleted.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessMessagesDeleted.kt
@@ -3,6 +3,14 @@ package eu.vendeli.tgbot.types.business
 import eu.vendeli.tgbot.types.chat.Chat
 import kotlinx.serialization.Serializable
 
+/**
+ * This object is received when messages are deleted from a connected business account.
+ *
+ * Api reference: https://core.telegram.org/bots/api#businessmessagesdeleted
+ * @property businessConnectionId Unique identifier of the business connection
+ * @property chat Information about a chat in the business account. The bot may not have access to the chat or the corresponding user.
+ * @property messageIds A JSON-serialized list of identifiers of deleted messages in the chat of the business account
+ */
 @Serializable
 data class BusinessMessagesDeleted(
     val businessConnectionId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessMessagesDeleted.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessMessagesDeleted.kt
@@ -7,5 +7,5 @@ import kotlinx.serialization.Serializable
 data class BusinessMessagesDeleted(
     val businessConnectionId: String,
     val chat: Chat,
-    val messageIds: List<Int>
+    val messageIds: List<Int>,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHours.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHours.kt
@@ -2,6 +2,13 @@ package eu.vendeli.tgbot.types.business
 
 import kotlinx.serialization.Serializable
 
+/**
+
+ *
+ * Api reference: https://core.telegram.org/bots/api#businessopeninghours
+ * @property timeZoneName Unique name of the time zone for which the opening hours are defined
+ * @property openingHours List of time intervals describing business opening hours
+ */
 @Serializable
 data class BusinessOpeningHours(
     val timeZoneName: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHours.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHours.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class BusinessOpeningHours(
     val timeZoneName: String,
-    val openingHours: List<BusinessOpeningHoursInterval>
+    val openingHours: List<BusinessOpeningHoursInterval>,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHours.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHours.kt
@@ -1,0 +1,9 @@
+package eu.vendeli.tgbot.types.business
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BusinessOpeningHours(
+    val timeZoneName: String,
+    val openingHours: List<BusinessOpeningHoursInterval>
+)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval.kt
@@ -2,6 +2,13 @@ package eu.vendeli.tgbot.types.business
 
 import kotlinx.serialization.Serializable
 
+/**
+
+ *
+ * Api reference: https://core.telegram.org/bots/api#businessopeninghoursinterval
+ * @property openingMinute The minute's sequence number in a week, starting on Monday, marking the start of the time interval during which the business is open; 0 - 7 24 60
+ * @property closingMinute The minute's sequence number in a week, starting on Monday, marking the end of the time interval during which the business is open; 0 - 8 24 60
+ */
 @Serializable
 data class BusinessOpeningHoursInterval(
     val openingMinute: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class BusinessOpeningHoursInterval(
     val openingMinute: Int,
-    val closingMinute: Int
+    val closingMinute: Int,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/business/BusinessOpeningHoursInterval.kt
@@ -1,0 +1,9 @@
+package eu.vendeli.tgbot.types.business
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BusinessOpeningHoursInterval(
+    val openingMinute: Int,
+    val closingMinute: Int
+)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/Chat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/Chat.kt
@@ -31,6 +31,7 @@ enum class ChatType {
 
 /**
  * This object represents a chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#chat
  * @property id Unique identifier for this chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this identifier.
  * @property type Type of chat, can be either "private", "group", "supergroup" or "channel"
@@ -41,6 +42,11 @@ enum class ChatType {
  * @property isForum Optional. True, if the supergroup chat is a forum (has topics enabled)
  * @property photo Optional. Chat photo. Returned only in getChat.
  * @property activeUsernames Optional. If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in getChat.
+ * @property birthdate Optional. For private chats, the date of birth of the user. Returned only in getChat.
+ * @property businessIntro Optional. For private chats with business accounts, the intro of the business. Returned only in getChat.
+ * @property businessLocation Optional. For private chats with business accounts, the location of the business. Returned only in getChat.
+ * @property businessOpeningHours Optional. For private chats with business accounts, the opening hours of the business. Returned only in getChat.
+ * @property personalChat Optional. For private chats, the personal channel of the user. Returned only in getChat.
  * @property availableReactions Optional. List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. Returned only in getChat.
  * @property accentColorId Optional. Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See accent colors for more details. Returned only in getChat. Always returned in getChat.
  * @property backgroundCustomEmojiId Optional. Custom emoji identifier of emoji chosen by the chat for the reply header and link preview background. Returned only in getChat.

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/Chat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/Chat.kt
@@ -1,7 +1,11 @@
 package eu.vendeli.tgbot.types.chat
 
+import eu.vendeli.tgbot.types.Birthdate
 import eu.vendeli.tgbot.types.Message
 import eu.vendeli.tgbot.types.ReactionType
+import eu.vendeli.tgbot.types.business.BusinessIntro
+import eu.vendeli.tgbot.types.business.BusinessLocation
+import eu.vendeli.tgbot.types.business.BusinessOpeningHours
 import eu.vendeli.tgbot.utils.serde.InstantSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
@@ -65,7 +69,7 @@ enum class ChatType {
  * @property customEmojiStickerSetName Optional. For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. Returned only in getChat.
  * @property linkedChatId Optional. Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. This identifier may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier. Returned only in getChat.
  * @property location Optional. For supergroups, the location to which the supergroup is connected. Returned only in getChat.
-*/
+ */
 @Serializable
 data class Chat(
     val id: Long,
@@ -77,6 +81,11 @@ data class Chat(
     val isForum: Boolean? = null,
     val photo: ChatPhoto? = null,
     val activeUsernames: List<String>? = null,
+    val birthdate: Birthdate? = null,
+    val businessIntro: BusinessIntro? = null,
+    val businessLocation: BusinessLocation? = null,
+    val businessOpeningHours: BusinessOpeningHours? = null,
+    val personalChat: Chat? = null,
     val availableReactions: List<ReactionType>? = null,
     val accentColorId: Int? = null,
     val backgroundCustomEmojiId: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatAdministratorRights.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatAdministratorRights.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Represents the rights of an administrator in a chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatadministratorrights
  * @property isAnonymous True, if the user's presence in the chat is hidden
  * @property canManageChat True, if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report spam messages and ignore slow mode. Implied by any other administrator privilege.
@@ -16,11 +17,11 @@ import kotlinx.serialization.Serializable
  * @property canPostStories True, if the administrator can post stories to the chat
  * @property canEditStories True, if the administrator can edit stories posted by other users
  * @property canDeleteStories True, if the administrator can delete stories posted by other users
- * @property canPostMessages Optional. True, if the administrator can post messages in the channel, or access channel statistics; channels only
- * @property canEditMessages Optional. True, if the administrator can edit messages of other users and can pin messages; channels only
- * @property canPinMessages Optional. True, if the user is allowed to pin messages; groups and supergroups only
- * @property canManageTopics Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only
-*/
+ * @property canPostMessages Optional. True, if the administrator can post messages in the channel, or access channel statistics; for channels only
+ * @property canEditMessages Optional. True, if the administrator can edit messages of other users and can pin messages; for channels only
+ * @property canPinMessages Optional. True, if the user is allowed to pin messages; for groups and supergroups only
+ * @property canManageTopics Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only
+ */
 @Serializable
 data class ChatAdministratorRights(
     val isAnonymous: Boolean,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatInviteLink.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatInviteLink.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Represents an invite link for a chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatinvitelink
  * @property inviteLink The invite link. If the link was created by another chat administrator, then the second part of the link will be replaced with "...".
  * @property creator Creator of the link
@@ -17,7 +18,7 @@ import kotlinx.serialization.Serializable
  * @property expireDate Optional. Point in time (Unix timestamp) when the link will expire or has been expired
  * @property memberLimit Optional. The maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
  * @property pendingJoinRequestCount Optional. Number of pending join requests created using this link
-*/
+ */
 @Serializable
 data class ChatInviteLink(
     val inviteLink: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatJoinRequest.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatJoinRequest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Represents a join request sent to a chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatjoinrequest
  * @property chat Chat to which the request was sent
  * @property from User that sent the join request
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property date Date the request was sent in Unix time
  * @property bio Optional. Bio of the user.
  * @property inviteLink Optional. Chat invite link that was used by the user to send the join request
-*/
+ */
 @Serializable
 data class ChatJoinRequest(
     val chat: Chat,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatLocation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatLocation.kt
@@ -5,10 +5,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * Represents a location to which a chat is connected.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatlocation
  * @property location The location to which the supergroup is connected. Can't be a live location.
  * @property address Location address; 1-64 characters, as defined by the chat owner
-*/
+ */
 @Serializable
 data class ChatLocation(
     val location: LocationContent,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatMemberUpdated.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatMemberUpdated.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents changes in the status of a chat member.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatmemberupdated
  * @property chat Chat the user belongs to
  * @property from Performer of the action, which resulted in the change
@@ -15,7 +16,7 @@ import kotlinx.serialization.Serializable
  * @property newChatMember New information about the chat member
  * @property inviteLink Optional. Chat invite link, which was used by the user to join the chat; for joining by invite link events only.
  * @property viaChatFolderInviteLink Optional. True, if the user joined the chat via a chat folder invite link
-*/
+ */
 @Serializable
 data class ChatMemberUpdated(
     val chat: Chat,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatPermissions.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatPermissions.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes actions that a non-administrator user is allowed to take in a chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatpermissions
  * @property canSendMessages Optional. True, if the user is allowed to send text messages, contacts, giveaways, giveaway winners, invoices, locations and venues
  * @property canSendAudios Optional. True, if the user is allowed to send audios
@@ -19,7 +20,7 @@ import kotlinx.serialization.Serializable
  * @property canInviteUsers Optional. True, if the user is allowed to invite new users to the chat
  * @property canPinMessages Optional. True, if the user is allowed to pin messages. Ignored in public supergroups
  * @property canManageTopics Optional. True, if the user is allowed to create forum topics. If omitted defaults to the value of can_pin_messages
-*/
+ */
 @Serializable
 data class ChatPermissions(
     var canSendMessages: Boolean? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatPhoto.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatPhoto.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a chat photo.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatphoto
  * @property smallFileId File identifier of small (160x160) chat photo. This file_id can be used only for photo download and only for as long as the photo is not changed.
  * @property smallFileUniqueId Unique file identifier of small (160x160) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property bigFileId File identifier of big (640x640) chat photo. This file_id can be used only for photo download and only for as long as the photo is not changed.
  * @property bigFileUniqueId Unique file identifier of big (640x640) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-*/
+ */
 @Serializable
 data class ChatPhoto(
     val smallFileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatShared.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatShared.kt
@@ -15,5 +15,5 @@ data class ChatShared(
     val chatId: Long,
     val title: String? = null,
     val username: String? = null,
-    val photo: List<PhotoSize>? = null
+    val photo: List<PhotoSize>? = null,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatShared.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatShared.kt
@@ -1,5 +1,6 @@
 package eu.vendeli.tgbot.types.chat
 
+import eu.vendeli.tgbot.types.media.PhotoSize
 import kotlinx.serialization.Serializable
 
 /**
@@ -12,4 +13,7 @@ import kotlinx.serialization.Serializable
 data class ChatShared(
     val requestId: Int,
     val chatId: Long,
+    val title: String? = null,
+    val username: String? = null,
+    val photo: List<PhotoSize>? = null
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatShared.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/chat/ChatShared.kt
@@ -4,11 +4,15 @@ import eu.vendeli.tgbot.types.media.PhotoSize
 import kotlinx.serialization.Serializable
 
 /**
- * This object contains information about the chat whose identifier was shared with the bot using a KeyboardButtonRequestChat button.
+ * This object contains information about a chat that was shared with the bot using a KeyboardButtonRequestChat button.
+ *
  * Api reference: https://core.telegram.org/bots/api#chatshared
  * @property requestId Identifier of the request
  * @property chatId Identifier of the shared chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the chat and could be unable to use this identifier, unless the chat is already known to the bot by some other means.
-*/
+ * @property title Optional. Title of the chat, if the title was requested by the bot.
+ * @property username Optional. Username of the chat, if the username was requested by the bot and available.
+ * @property photo Optional. Available sizes of the chat photo, if the photo was requested by the bot
+ */
 @Serializable
 data class ChatShared(
     val requestId: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/forum/ForumTopic.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/forum/ForumTopic.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a forum topic.
+ *
  * Api reference: https://core.telegram.org/bots/api#forumtopic
  * @property messageThreadId Unique identifier of the forum topic
  * @property name Name of the topic
  * @property iconColor Color of the topic icon in RGB format
  * @property iconCustomEmojiId Optional. Unique identifier of the custom emoji shown as the topic icon
-*/
+ */
 @Serializable
 data class ForumTopic(
     val messageThreadId: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/forum/ForumTopicCreated.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/forum/ForumTopicCreated.kt
@@ -4,11 +4,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about a new forum topic created in the chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#forumtopiccreated
  * @property name Name of the topic
  * @property iconColor Color of the topic icon in RGB format
  * @property iconCustomEmojiId Optional. Unique identifier of the custom emoji shown as the topic icon
-*/
+ */
 @Serializable
 data class ForumTopicCreated(
     val name: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/forum/ForumTopicEdited.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/forum/ForumTopicEdited.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about an edited forum topic.
+ *
  * Api reference: https://core.telegram.org/bots/api#forumtopicedited
  * @property name Optional. New name of the topic, if it was edited
  * @property iconCustomEmojiId Optional. New identifier of the custom emoji shown as the topic icon, if it was edited; an empty string if the icon was removed
-*/
+ */
 @Serializable
 data class ForumTopicEdited(
     val name: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/game/Dice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/game/Dice.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents an animated emoji that displays a random value.
+ *
  * Api reference: https://core.telegram.org/bots/api#dice
  * @property emoji Emoji on which the dice throw animation is based
  * @property value Value of the dice, 1-6 for "🎲", "🎯" and "🎳" base emoji, 1-5 for "🏀" and "⚽" base emoji, 1-64 for "🎰" base emoji
-*/
+ */
 @Serializable
 data class Dice(
     val emoji: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/game/Game.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/game/Game.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a game. Use BotFather to create and edit games, their short names will act as unique identifiers.
+ *
  * Api reference: https://core.telegram.org/bots/api#game
  * @property title Title of the game
  * @property description Description of the game
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property text Optional. Brief description of the game or high scores included in the game message. Can be automatically edited to include current high scores for the game when the bot calls setGameScore, or manually edited using editMessageText. 0-4096 characters.
  * @property textEntities Optional. Special entities that appear in text, such as usernames, URLs, bot commands, etc.
  * @property animation Optional. Animation that will be displayed in the game message in chats. Upload via BotFather
-*/
+ */
 @Serializable
 data class Game(
     val title: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/game/GameHighScore.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/game/GameHighScore.kt
@@ -6,11 +6,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents one row of the high scores table for a game.
+ *
  * Api reference: https://core.telegram.org/bots/api#gamehighscore
  * @property position Position in high score table for the game
  * @property user User
  * @property score Score
-*/
+ */
 @Serializable
 data class GameHighScore(
     val position: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/ChosenInlineResult.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/ChosenInlineResult.kt
@@ -7,13 +7,14 @@ import kotlinx.serialization.Serializable
 /**
  * Represents a result of an inline query that was chosen by the user and sent to their chat partner.
  * Note: It is necessary to enable inline feedback via @BotFather in order to receive these objects in updates.
+ *
  * Api reference: https://core.telegram.org/bots/api#choseninlineresult
  * @property resultId The unique identifier for the result that was chosen
  * @property from The user that chose the result
  * @property location Optional. Sender location, only for bots that require user location
  * @property inlineMessageId Optional. Identifier of the sent inline message. Available only if there is an inline keyboard attached to the message. Will be also received in callback queries and can be used to edit the message.
  * @property query The query that was used to obtain the result
-*/
+ */
 @Serializable
 data class ChosenInlineResult(
     val resultId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/InlineQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/InlineQuery.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents an incoming inline query. When the user sends an empty query, your bot could return some default or trending results.
+ *
  * Api reference: https://core.telegram.org/bots/api#inlinequery
  * @property id Unique identifier for this query
  * @property from Sender
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property offset Offset of the results to be returned, can be controlled by the bot
  * @property chatType Optional. Type of the chat from which the inline query was sent. Can be either "sender" for a private chat with the inline query sender, "private", "group", "supergroup", or "channel". The chat type should be always known for requests sent from official clients and most third-party clients, unless the request was sent from a secret chat
  * @property location Optional. Sender location, only for bots that request user location
-*/
+ */
 @Serializable
 data class InlineQuery(
     val id: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/InlineQueryResult.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/InlineQueryResult.kt
@@ -30,9 +30,10 @@ import kotlinx.serialization.Serializable
  * - InlineQueryResultVideo
  * - InlineQueryResultVoice
  * Note: All URLs passed in inline query results will be available to end users and therefore must be assumed to be public.
+ *
  * Api reference: https://core.telegram.org/bots/api#inlinequeryresult
  *
-*/
+ */
 @Serializable
 sealed class InlineQueryResult(val type: String) {
     @Serializable

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/InlineQueryResultsButton.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/InlineQueryResultsButton.kt
@@ -5,11 +5,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a button to be shown above inline query results. You must use exactly one of the optional fields.
+ *
  * Api reference: https://core.telegram.org/bots/api#inlinequeryresultsbutton
  * @property text Label text on the button
  * @property webApp Optional. Description of the Web App that will be launched when the user presses the button. The Web App will be able to switch back to the inline mode using the method switchInlineQuery inside the Web App.
  * @property startParameter Optional. Deep-linking parameter for the /start message sent to the bot when a user presses the button. 1-64 characters, only A-Z, a-z, 0-9, _ and - are allowed. Example: An inline bot that sends YouTube videos can ask the user to connect the bot to their YouTube account to adapt search results accordingly. To do this, it displays a 'Connect your YouTube account' button above the results, or even before showing any. The user presses the button, switches to a private chat with the bot and, in doing so, passes a start parameter that instructs the bot to return an OAuth link. Once done, the bot can offer a switch_inline button so that the user can easily return to the chat where they wanted to use the bot's inline capabilities.
-*/
+ */
 @Serializable
 data class InlineQueryResultsButton(
     val text: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/SwitchInlineQueryChosenChat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/inline/SwitchInlineQueryChosenChat.kt
@@ -4,13 +4,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents an inline button that switches the current user to inline mode in a chosen chat, with an optional default inline query.
+ *
  * Api reference: https://core.telegram.org/bots/api#switchinlinequerychosenchat
  * @property query Optional. The default inline query to be inserted in the input field. If left empty, only the bot's username will be inserted
  * @property allowUserChats Optional. True, if private chats with users can be chosen
  * @property allowBotChats Optional. True, if private chats with bots can be chosen
  * @property allowGroupChats Optional. True, if group and supergroup chats can be chosen
  * @property allowChannelChats Optional. True, if channel chats can be chosen
-*/
+ */
 @Serializable
 data class SwitchInlineQueryChosenChat(
     val query: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/ProcessedUpdate.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/ProcessedUpdate.kt
@@ -1,8 +1,6 @@
 package eu.vendeli.tgbot.types.internal
 
 import eu.vendeli.tgbot.types.CallbackQuery
-import eu.vendeli.tgbot.types.boost.ChatBoostRemoved
-import eu.vendeli.tgbot.types.boost.ChatBoostUpdated
 import eu.vendeli.tgbot.types.Message
 import eu.vendeli.tgbot.types.MessageReactionCountUpdated
 import eu.vendeli.tgbot.types.MessageReactionUpdated
@@ -10,6 +8,10 @@ import eu.vendeli.tgbot.types.Poll
 import eu.vendeli.tgbot.types.PollAnswer
 import eu.vendeli.tgbot.types.Update
 import eu.vendeli.tgbot.types.User
+import eu.vendeli.tgbot.types.boost.ChatBoostRemoved
+import eu.vendeli.tgbot.types.boost.ChatBoostUpdated
+import eu.vendeli.tgbot.types.business.BusinessConnection
+import eu.vendeli.tgbot.types.business.BusinessMessagesDeleted
 import eu.vendeli.tgbot.types.chat.ChatJoinRequest
 import eu.vendeli.tgbot.types.chat.ChatMemberUpdated
 import eu.vendeli.tgbot.types.inline.ChosenInlineResult
@@ -67,6 +69,38 @@ data class EditedChannelPostUpdate(
     override val user = editedChannelPost.from
     override val text = editedChannelPost.text.orEmpty()
 }
+
+data class BusinessConnectionUpdate(
+    override val updateId: Int,
+    override val update: Update,
+    val businessConnection: BusinessConnection,
+) : ProcessedUpdate(updateId, update, UpdateType.BUSINESS_CONNECTION), UserReference {
+    override val user = businessConnection.user
+}
+
+data class BusinessMessageUpdate(
+    override val updateId: Int,
+    override val update: Update,
+    val businessMessage: Message,
+) : ProcessedUpdate(updateId, update, UpdateType.BUSINESS_MESSAGE), UserReference {
+    override val user = businessMessage.from
+    override val text = businessMessage.text.orEmpty()
+}
+
+data class EditedBusinessMessageUpdate(
+    override val updateId: Int,
+    override val update: Update,
+    val editedBusinessMessage: Message,
+) : ProcessedUpdate(updateId, update, UpdateType.EDITED_BUSINESS_MESSAGE), UserReference {
+    override val user = editedBusinessMessage.from
+    override val text = editedBusinessMessage.text.orEmpty()
+}
+
+data class DeletedBusinessMessagesUpdate(
+    override val updateId: Int,
+    override val update: Update,
+    val deletedBusinessMessages: BusinessMessagesDeleted,
+) : ProcessedUpdate(updateId, update, UpdateType.DELETED_BUSINESS_MESSAGES)
 
 data class MessageReactionUpdate(
     override val updateId: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/UpdateType.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/UpdateType.kt
@@ -17,6 +17,18 @@ enum class UpdateType {
     @SerialName("edited_channel_post")
     EDITED_CHANNEL_POST,
 
+    @SerialName("business_connection")
+    BUSINESS_CONNECTION,
+
+    @SerialName("business_message")
+    BUSINESS_MESSAGE,
+
+    @SerialName("edited_business_message")
+    EDITED_BUSINESS_MESSAGE,
+
+    @SerialName("deleted_business_messages")
+    DELETED_BUSINESS_MESSAGES,
+
     @SerialName("message_reaction")
     MESSAGE_REACTION,
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/ForceReply.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/ForceReply.kt
@@ -5,11 +5,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * Upon receiving a message with this object, Telegram clients will display a reply interface to the user (act as if the user has selected the bot's message and tapped 'Reply'). This can be extremely useful if you want to create user-friendly step-by-step interfaces without having to sacrifice privacy mode.
+ *
  * Api reference: https://core.telegram.org/bots/api#forcereply
  * @property forceReply Shows reply interface to the user, as if they manually selected the bot's message and tapped 'Reply'
  * @property inputFieldPlaceholder Optional. The placeholder to be shown in the input field when the reply is active; 1-64 characters
  * @property selective Optional. Use this parameter if you want to force reply from specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message.
-*/
+ */
 @Serializable
 data class ForceReply(
     val inputFieldPlaceholder: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/InlineKeyboardButton.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/InlineKeyboardButton.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents one button of an inline keyboard. You must use exactly one of the optional fields.
+ *
  * Api reference: https://core.telegram.org/bots/api#inlinekeyboardbutton
  * @property text Label text on the button
  * @property url Optional. HTTP or tg:// URL to be opened when the button is pressed. Links tg://user?id=<user_id> can be used to mention a user by their identifier without using a username, if this is allowed by their privacy settings.
@@ -18,7 +19,7 @@ import kotlinx.serialization.Serializable
  * @property switchInlineQueryChosenChat Optional. If set, pressing the button will prompt the user to select one of their chats of the specified type, open that chat and insert the bot's username and the specified inline query in the input field
  * @property callbackGame Optional. Description of the game that will be launched when the user presses the button. NOTE: This type of button must always be the first button in the first row.
  * @property pay Optional. Specify True, to send a Pay button. NOTE: This type of button must always be the first button in the first row and can only be used in invoice messages.
-*/
+ */
 @Serializable
 data class InlineKeyboardButton(
     val text: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButton.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButton.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 /**
  * This object represents one button of the reply keyboard. For simple text buttons, String can be used instead of this object to specify the button text. The optional fields web_app, request_users, request_chat, request_contact, request_location, and request_poll are mutually exclusive.
  * Note: request_users and request_chat options will only work in Telegram versions released after 3 February, 2023. Older clients will display unsupported message.
+ *
  * Api reference: https://core.telegram.org/bots/api#keyboardbutton
  * @property text Text of the button. If none of the optional fields are used, it will be sent as a message when the button is pressed
  * @property requestUsers Optional. If specified, pressing the button will open a list of suitable users. Identifiers of selected users will be sent to the bot in a "users_shared" service message. Available in private chats only.
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property requestLocation Optional. If True, the user's current location will be sent when the button is pressed. Available in private chats only.
  * @property requestPoll Optional. If specified, the user will be asked to create a poll and send it to the bot when the button is pressed. Available in private chats only.
  * @property webApp Optional. If specified, the described Web App will be launched when the button is pressed. The Web App will be able to send a "web_app_data" service message. Available in private chats only.
-*/
+ */
 @Serializable
 data class KeyboardButton(
     val text: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonPollType.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonPollType.kt
@@ -5,8 +5,9 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents type of a poll, which is allowed to be created and sent when the corresponding button is pressed.
+ *
  * Api reference: https://core.telegram.org/bots/api#keyboardbuttonpolltype
  * @property type Optional. If quiz is passed, the user will be allowed to create only polls in the quiz mode. If regular is passed, only regular polls will be allowed. Otherwise, the user will be allowed to create a poll of any type.
-*/
+ */
 @Serializable
 data class KeyboardButtonPollType(val type: PollType? = null)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat.kt
@@ -4,7 +4,8 @@ import eu.vendeli.tgbot.types.chat.ChatAdministratorRights
 import kotlinx.serialization.Serializable
 
 /**
- * This object defines the criteria used to request a suitable chat. The identifier of the selected chat will be shared with the bot when the corresponding button is pressed. More about requesting chats: https://core.telegram.org/bots/features#chat-and-user-selection
+ * This object defines the criteria used to request a suitable chat. Information about the selected chat will be shared with the bot when the corresponding button is pressed. The bot will be granted requested rights in the сhat if appropriate More about requesting chats: https://core.telegram.org/bots/features#chat-and-user-selection
+ *
  * Api reference: https://core.telegram.org/bots/api#keyboardbuttonrequestchat
  * @property requestId Signed 32-bit identifier of the request, which will be received back in the ChatShared object. Must be unique within the message
  * @property chatIsChannel Pass True to request a channel chat, pass False to request a group or a supergroup chat.
@@ -14,7 +15,10 @@ import kotlinx.serialization.Serializable
  * @property userAdministratorRights Optional. A JSON-serialized object listing the required administrator rights of the user in the chat. The rights must be a superset of bot_administrator_rights. If not specified, no additional restrictions are applied.
  * @property botAdministratorRights Optional. A JSON-serialized object listing the required administrator rights of the bot in the chat. The rights must be a subset of user_administrator_rights. If not specified, no additional restrictions are applied.
  * @property botIsMember Optional. Pass True to request a chat with the bot as a member. Otherwise, no additional restrictions are applied.
-*/
+ * @property requestTitle Optional. Pass True to request the chat's title
+ * @property requestUsername Optional. Pass True to request the chat's username
+ * @property requestPhoto Optional. Pass True to request the chat's photo
+ */
 @Serializable
 data class KeyboardButtonRequestChat(
     val requestId: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat.kt
@@ -27,5 +27,5 @@ data class KeyboardButtonRequestChat(
     val botIsMember: Boolean? = null,
     val requestTitle: Boolean? = null,
     val requestUsername: Boolean? = null,
-    val requestPhoto: Boolean? = null
+    val requestPhoto: Boolean? = null,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestChat.kt
@@ -20,9 +20,12 @@ data class KeyboardButtonRequestChat(
     val requestId: Int,
     val chatIsChannel: Boolean,
     val chatIsForum: Boolean? = null,
-    val chatHasUserName: Boolean? = null,
+    val chatHasUsername: Boolean? = null,
     val chatIsCreated: Boolean? = null,
     val userAdministratorRights: ChatAdministratorRights? = null,
     val botAdministratorRights: ChatAdministratorRights? = null,
     val botIsMember: Boolean? = null,
+    val requestTitle: Boolean? = null,
+    val requestUsername: Boolean? = null,
+    val requestPhoto: Boolean? = null
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers.kt
@@ -9,11 +9,14 @@ import kotlinx.serialization.Serializable
  * @property userIsBot Optional. Pass True to request bots, pass False to request regular users. If not specified, no additional restrictions are applied.
  * @property userIsPremium Optional. Pass True to request premium users, pass False to request non-premium users. If not specified, no additional restrictions are applied.
  * @property maxQuantity Optional. The maximum number of users to be selected; 1-10. Defaults to 1.
-*/
+ */
 @Serializable
 data class KeyboardButtonRequestUsers(
     val requestId: Int,
     val userIsBot: Boolean? = null,
     val userIsPremium: Boolean? = null,
     val maxQuantity: Int? = null,
+    val requestName: Boolean? = null,
+    val requestUsername: Boolean? = null,
+    val requestPhoto: Boolean? = null,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/KeyboardButtonRequestUsers.kt
@@ -3,12 +3,16 @@ package eu.vendeli.tgbot.types.keyboard
 import kotlinx.serialization.Serializable
 
 /**
- * This object defines the criteria used to request suitable users. The identifiers of the selected users will be shared with the bot when the corresponding button is pressed. More about requesting users: https://core.telegram.org/bots/features#chat-and-user-selection
+ * This object defines the criteria used to request suitable users. Information about the selected users will be shared with the bot when the corresponding button is pressed. More about requesting users: https://core.telegram.org/bots/features#chat-and-user-selection
+ *
  * Api reference: https://core.telegram.org/bots/api#keyboardbuttonrequestusers
  * @property requestId Signed 32-bit identifier of the request that will be received back in the UsersShared object. Must be unique within the message
  * @property userIsBot Optional. Pass True to request bots, pass False to request regular users. If not specified, no additional restrictions are applied.
  * @property userIsPremium Optional. Pass True to request premium users, pass False to request non-premium users. If not specified, no additional restrictions are applied.
  * @property maxQuantity Optional. The maximum number of users to be selected; 1-10. Defaults to 1.
+ * @property requestName Optional. Pass True to request the users' first and last name
+ * @property requestUsername Optional. Pass True to request the users' username
+ * @property requestPhoto Optional. Pass True to request the users' photo
  */
 @Serializable
 data class KeyboardButtonRequestUsers(

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/LoginUrl.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/LoginUrl.kt
@@ -5,12 +5,13 @@ import kotlinx.serialization.Serializable
 /**
  * This object represents a parameter of the inline keyboard button used to automatically authorize a user. Serves as a great replacement for the Telegram Login Widget when the user is coming from Telegram. All the user needs to do is tap/click a button and confirm that they want to log in:
  * Telegram apps support these buttons as of version 5.7.
+ *
  * Api reference: https://core.telegram.org/bots/api#loginurl
  * @property url An HTTPS URL to be opened with user authorization data added to the query string when the button is pressed. If the user refuses to provide authorization data, the original URL without information about the user will be opened. The data added is the same as described in Receiving authorization data. NOTE: You must always check the hash of the received data to verify the authentication and the integrity of the data as described in Checking authorization.
  * @property forwardText Optional. New text of the button in forwarded messages.
  * @property botUsername Optional. Username of a bot, which will be used for user authorization. See Setting up a bot for more details. If not specified, the current bot's username will be assumed. The url's domain must be the same as the domain linked with the bot. See Linking your domain to the bot for more details.
  * @property requestWriteAccess Optional. Pass True to request the permission for your bot to send messages to the user.
-*/
+ */
 @Serializable
 data class LoginUrl(
     val url: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/MenuButton.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/MenuButton.kt
@@ -9,9 +9,10 @@ import kotlinx.serialization.Serializable
  * - MenuButtonWebApp
  * - MenuButtonDefault
  * If a menu button other than MenuButtonDefault is set for a private chat, then it is applied in the chat. Otherwise the default menu button is applied. By default, the menu button opens the list of bot commands.
+ *
  * Api reference: https://core.telegram.org/bots/api#menubutton
  *
-*/
+ */
 @Serializable
 sealed class MenuButton(open val type: String) {
     @Serializable

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/ReplyKeyboardRemove.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/ReplyKeyboardRemove.kt
@@ -5,10 +5,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * Upon receiving a message with this object, Telegram clients will remove the current custom keyboard and display the default letter-keyboard. By default, custom keyboards are displayed until a new keyboard is sent by a bot. An exception is made for one-time keyboards that are hidden immediately after the user presses a button (see ReplyKeyboardMarkup).
+ *
  * Api reference: https://core.telegram.org/bots/api#replykeyboardremove
  * @property removeKeyboard Requests clients to remove the custom keyboard (user will not be able to summon this keyboard; if you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in ReplyKeyboardMarkup)
  * @property selective Optional. Use this parameter if you want to remove the keyboard for specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply to a message in the same chat and forum topic, sender of the original message. Example: A user votes in a poll, bot returns confirmation message in reply to the vote and removes the keyboard for that user, while still showing the keyboard with poll options to users who haven't voted yet.
-*/
+ */
 @Serializable
 data class ReplyKeyboardRemove(val selective: Boolean? = null) : Keyboard {
     val removeKeyboard: Boolean = true

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/WebAppData.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/WebAppData.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes data sent from a Web App to the bot.
+ *
  * Api reference: https://core.telegram.org/bots/api#webappdata
  * @property data The data. Be aware that a bad client can send arbitrary data in this field.
  * @property buttonText Text of the web_app keyboard button from which the Web App was opened. Be aware that a bad client can send arbitrary data in this field.
-*/
+ */
 @Serializable
 data class WebAppData(
     val data: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/WebAppInfo.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/keyboard/WebAppInfo.kt
@@ -4,8 +4,9 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes a Web App.
+ *
  * Api reference: https://core.telegram.org/bots/api#webappinfo
  * @property url An HTTPS URL of a Web App to be opened with additional data as specified in Initializing Web Apps
-*/
+ */
 @Serializable
 data class WebAppInfo(val url: String)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Animation.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Animation.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents an animation file (GIF or H.264/MPEG-4 AVC video without sound).
+ *
  * Api reference: https://core.telegram.org/bots/api#animation
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property fileName Optional. Original animation filename as defined by sender
  * @property mimeType Optional. MIME type of the file as defined by sender
  * @property fileSize Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this value.
-*/
+ */
 @Serializable
 data class Animation(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Audio.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Audio.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents an audio file to be treated as music by the Telegram clients.
+ *
  * Api reference: https://core.telegram.org/bots/api#audio
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property mimeType Optional. MIME type of the file as defined by sender
  * @property fileSize Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this value.
  * @property thumbnail Optional. Thumbnail of the album cover to which the music file belongs
-*/
+ */
 @Serializable
 data class Audio(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Document.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Document.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a general file (as opposed to photos, voice messages and audio files).
+ *
  * Api reference: https://core.telegram.org/bots/api#document
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
@@ -11,7 +12,7 @@ import kotlinx.serialization.Serializable
  * @property fileName Optional. Original filename as defined by sender
  * @property mimeType Optional. MIME type of the file as defined by sender
  * @property fileSize Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this value.
-*/
+ */
 @Serializable
 data class Document(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/File.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/File.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a file ready to be downloaded. The file can be downloaded via the link https://api.telegram.org/file/bot<token>/<file_path>. It is guaranteed that the link will be valid for at least 1 hour. When the link expires, a new one can be requested by calling getFile.
+ *
  * Api reference: https://core.telegram.org/bots/api#file
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property fileSize Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this value.
  * @property filePath Optional. File path. Use https://api.telegram.org/file/bot<token>/<file_path> to get the file.
-*/
+ */
 @Serializable
 data class File(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/InputMedia.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/InputMedia.kt
@@ -13,9 +13,10 @@ import kotlinx.serialization.Serializable
  * - InputMediaAudio
  * - InputMediaPhoto
  * - InputMediaVideo
+ *
  * Api reference: https://core.telegram.org/bots/api#inputmedia
  *
-*/
+ */
 @Serializable
 sealed class InputMedia(val type: String) {
     abstract var media: ImplicitFile

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/InputSticker.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/InputSticker.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class InputSticker(
     var sticker: ImplicitFile,
+    val format: StickerFormat,
     val emojiList: List<String>,
     val maskPosition: MaskPosition? = null,
     val keywords: List<String>? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/InputSticker.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/InputSticker.kt
@@ -5,12 +5,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object describes a sticker to be added to a sticker set.
+ *
  * Api reference: https://core.telegram.org/bots/api#inputsticker
  * @property sticker The added sticker. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, upload a new one using multipart/form-data, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name. Animated and video stickers can't be uploaded via HTTP URL. More information on Sending Files: https://core.telegram.org/bots/api#sending-files
+ * @property format Format of the added sticker, must be one of "static" for a .WEBP or .PNG image, "animated" for a .TGS animation, "video" for a WEBM video
  * @property emojiList List of 1-20 emoji associated with the sticker
  * @property maskPosition Optional. Position where the mask should be placed on faces. For "mask" stickers only.
  * @property keywords Optional. List of 0-20 search keywords for the sticker with total length of up to 64 characters. For "regular" and "custom_emoji" stickers only.
-*/
+ */
 @Serializable
 data class InputSticker(
     var sticker: ImplicitFile,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/MaskPosition.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/MaskPosition.kt
@@ -5,12 +5,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object describes the position on faces where a mask should be placed by default.
+ *
  * Api reference: https://core.telegram.org/bots/api#maskposition
  * @property point The part of the face relative to which the mask should be placed. One of "forehead", "eyes", "mouth", or "chin".
  * @property xShift Shift by X-axis measured in widths of the mask scaled to the face size, from left to right. For example, choosing -1.0 will place mask just to the left of the default mask position.
  * @property yShift Shift by Y-axis measured in heights of the mask scaled to the face size, from top to bottom. For example, 1.0 will place the mask just below the default mask position.
  * @property scale Mask scaling coefficient. For example, 2.0 means double size.
-*/
+ */
 @Serializable
 data class MaskPosition(
     val point: MaskPoint,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/PhotoSize.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/PhotoSize.kt
@@ -4,13 +4,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents one size of a photo or a file / sticker thumbnail.
+ *
  * Api reference: https://core.telegram.org/bots/api#photosize
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property width Photo width
  * @property height Photo height
  * @property fileSize Optional. File size in bytes
-*/
+ */
 @Serializable
 data class PhotoSize(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Sticker.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Sticker.kt
@@ -18,6 +18,7 @@ enum class StickerFormat {
 
 /**
  * This object represents a sticker.
+ *
  * Api reference: https://core.telegram.org/bots/api#sticker
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
@@ -34,7 +35,7 @@ enum class StickerFormat {
  * @property customEmojiId Optional. For custom emoji stickers, unique identifier of the custom emoji
  * @property needsRepainting Optional. True, if the sticker must be repainted to a text color in messages, the color of the Telegram Premium badge in emoji status, white color on chat photos, or another appropriate color in other places
  * @property fileSize Optional. File size in bytes
-*/
+ */
 @Serializable
 data class Sticker(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/StickerSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/StickerSet.kt
@@ -17,15 +17,14 @@ enum class StickerType {
 
 /**
  * This object represents a sticker set.
+ *
  * Api reference: https://core.telegram.org/bots/api#stickerset
  * @property name Sticker set name
  * @property title Sticker set title
  * @property stickerType Type of stickers in the set, currently one of "regular", "mask", "custom_emoji"
- * @property isAnimated True, if the sticker set contains animated stickers
- * @property isVideo True, if the sticker set contains video stickers
  * @property stickers List of all set stickers
  * @property thumbnail Optional. Sticker set thumbnail in the .WEBP, .TGS, or .WEBM format
-*/
+ */
 @Serializable
 data class StickerSet(
     val name: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/StickerSet.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/StickerSet.kt
@@ -31,8 +31,6 @@ data class StickerSet(
     val name: String,
     val title: String,
     val stickerType: StickerType,
-    val isAnimated: Boolean,
-    val isVideo: Boolean,
     val stickers: List<Sticker>,
     val thumbnail: PhotoSize? = null,
 )

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Story.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Story.kt
@@ -5,10 +5,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a story.
+ *
  * Api reference: https://core.telegram.org/bots/api#story
  * @property chat Chat that posted the story
  * @property id Unique identifier for the story in the chat
-*/
+ */
 @Serializable
 data class Story(
     val id: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Video.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Video.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a video file.
+ *
  * Api reference: https://core.telegram.org/bots/api#video
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property fileName Optional. Original filename as defined by sender
  * @property mimeType Optional. MIME type of the file as defined by sender
  * @property fileSize Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this value.
-*/
+ */
 @Serializable
 data class Video(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/VideoChatEnded.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/VideoChatEnded.kt
@@ -4,9 +4,10 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about a video chat ended in the chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#videochatended
  * @property duration Video chat duration in seconds
-*/
+ */
 @Serializable
 data class VideoChatEnded(
     val duration: Int,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/VideoChatParticipantsInvited.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/VideoChatParticipantsInvited.kt
@@ -5,9 +5,10 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about new members invited to a video chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#videochatparticipantsinvited
  * @property users New members that were invited to the video chat
-*/
+ */
 @Serializable
 data class VideoChatParticipantsInvited(
     val users: List<User>,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/VideoChatScheduled.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/VideoChatScheduled.kt
@@ -6,9 +6,10 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a service message about a video chat scheduled in the chat.
+ *
  * Api reference: https://core.telegram.org/bots/api#videochatscheduled
  * @property startDate Point in time (Unix timestamp) when the video chat is supposed to be started by a chat administrator
-*/
+ */
 @Serializable
 data class VideoChatScheduled(
     @Serializable(InstantSerializer::class)

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/VideoNote.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/VideoNote.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a video message (available in Telegram apps as of v.4.0).
+ *
  * Api reference: https://core.telegram.org/bots/api#videonote
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
@@ -11,7 +12,7 @@ import kotlinx.serialization.Serializable
  * @property duration Duration of the video in seconds as defined by sender
  * @property thumbnail Optional. Video thumbnail
  * @property fileSize Optional. File size in bytes
-*/
+ */
 @Serializable
 data class VideoNote(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Voice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/media/Voice.kt
@@ -4,13 +4,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a voice note.
+ *
  * Api reference: https://core.telegram.org/bots/api#voice
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property duration Duration of the audio in seconds as defined by sender
  * @property mimeType Optional. MIME type of the file as defined by sender
  * @property fileSize Optional. File size in bytes. It can be bigger than 2^31 and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this value.
-*/
+ */
 @Serializable
 data class Voice(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/passport/EncryptedCredentials.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/passport/EncryptedCredentials.kt
@@ -4,11 +4,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes data required for decrypting and authenticating EncryptedPassportElement. See the Telegram Passport Documentation for a complete description of the data decryption and authentication processes.
+ *
  * Api reference: https://core.telegram.org/bots/api#encryptedcredentials
  * @property data Base64-encoded encrypted JSON-serialized data with unique user's payload, data hashes and secrets required for EncryptedPassportElement decryption and authentication
  * @property hash Base64-encoded data hash for data authentication
  * @property secret Base64-encoded secret, encrypted with the bot's public RSA key, required for data decryption
-*/
+ */
 @Serializable
 data class EncryptedCredentials(
     val data: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/passport/EncryptedPassportElement.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/passport/EncryptedPassportElement.kt
@@ -47,18 +47,19 @@ enum class EncryptedPassportElementType {
 
 /**
  * Describes documents or other Telegram Passport elements shared with the bot by the user.
+ *
  * Api reference: https://core.telegram.org/bots/api#encryptedpassportelement
  * @property type Element type. One of "personal_details", "passport", "driver_license", "identity_card", "internal_passport", "address", "utility_bill", "bank_statement", "rental_agreement", "passport_registration", "temporary_registration", "phone_number", "email".
- * @property data Optional. Base64-encoded encrypted Telegram Passport element data provided by the user, available for "personal_details", "passport", "driver_license", "identity_card", "internal_passport" and "address" types. Can be decrypted and verified using the accompanying EncryptedCredentials.
- * @property phoneNumber Optional. User's verified phone number, available only for "phone_number" type
- * @property email Optional. User's verified email address, available only for "email" type
- * @property files Optional. Array of encrypted files with documents provided by the user, available for "utility_bill", "bank_statement", "rental_agreement", "passport_registration" and "temporary_registration" types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
- * @property frontSide Optional. Encrypted file with the front side of the document, provided by the user. Available for "passport", "driver_license", "identity_card" and "internal_passport". The file can be decrypted and verified using the accompanying EncryptedCredentials.
- * @property reverseSide Optional. Encrypted file with the reverse side of the document, provided by the user. Available for "driver_license" and "identity_card". The file can be decrypted and verified using the accompanying EncryptedCredentials.
- * @property selfie Optional. Encrypted file with the selfie of the user holding a document, provided by the user; available for "passport", "driver_license", "identity_card" and "internal_passport". The file can be decrypted and verified using the accompanying EncryptedCredentials.
- * @property translation Optional. Array of encrypted files with translated versions of documents provided by the user. Available if requested for "passport", "driver_license", "identity_card", "internal_passport", "utility_bill", "bank_statement", "rental_agreement", "passport_registration" and "temporary_registration" types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
+ * @property data Optional. Base64-encoded encrypted Telegram Passport element data provided by the user; available only for "personal_details", "passport", "driver_license", "identity_card", "internal_passport" and "address" types. Can be decrypted and verified using the accompanying EncryptedCredentials.
+ * @property phoneNumber Optional. User's verified phone number; available only for "phone_number" type
+ * @property email Optional. User's verified email address; available only for "email" type
+ * @property files Optional. Array of encrypted files with documents provided by the user; available only for "utility_bill", "bank_statement", "rental_agreement", "passport_registration" and "temporary_registration" types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
+ * @property frontSide Optional. Encrypted file with the front side of the document, provided by the user; available only for "passport", "driver_license", "identity_card" and "internal_passport". The file can be decrypted and verified using the accompanying EncryptedCredentials.
+ * @property reverseSide Optional. Encrypted file with the reverse side of the document, provided by the user; available only for "driver_license" and "identity_card". The file can be decrypted and verified using the accompanying EncryptedCredentials.
+ * @property selfie Optional. Encrypted file with the selfie of the user holding a document, provided by the user; available if requested for "passport", "driver_license", "identity_card" and "internal_passport". The file can be decrypted and verified using the accompanying EncryptedCredentials.
+ * @property translation Optional. Array of encrypted files with translated versions of documents provided by the user; available if requested for "passport", "driver_license", "identity_card", "internal_passport", "utility_bill", "bank_statement", "rental_agreement", "passport_registration" and "temporary_registration" types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
  * @property hash Base64-encoded element hash for using in PassportElementErrorUnspecified
-*/
+ */
 @Serializable
 data class EncryptedPassportElement(
     val type: EncryptedPassportElementType,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/passport/PassportData.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/passport/PassportData.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes Telegram Passport data shared with the bot by the user.
+ *
  * Api reference: https://core.telegram.org/bots/api#passportdata
  * @property data Array with information about documents and other Telegram Passport elements that was shared with the bot
  * @property credentials Encrypted credentials required to decrypt the data
-*/
+ */
 @Serializable
 data class PassportData(
     val data: List<EncryptedPassportElement>,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/passport/PassportFile.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/passport/PassportFile.kt
@@ -6,12 +6,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a file uploaded to Telegram Passport. Currently all Telegram Passport files are in JPEG format when decrypted and don't exceed 10MB.
+ *
  * Api reference: https://core.telegram.org/bots/api#passportfile
  * @property fileId Identifier for this file, which can be used to download or reuse the file
  * @property fileUniqueId Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property fileSize File size in bytes
  * @property fileDate Unix time when the file was uploaded
-*/
+ */
 @Serializable
 data class PassportFile(
     val fileId: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/Invoice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/Invoice.kt
@@ -5,13 +5,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains basic information about an invoice.
+ *
  * Api reference: https://core.telegram.org/bots/api#invoice
  * @property title Product name
  * @property description Product description
  * @property startParameter Unique bot deep-linking parameter that can be used to generate this invoice
  * @property currency Three-letter ISO 4217 currency code
  * @property totalAmount Total price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
-*/
+ */
 @Serializable
 data class Invoice(
     val title: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/LabeledPrice.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/LabeledPrice.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a portion of the price for goods or services.
+ *
  * Api reference: https://core.telegram.org/bots/api#labeledprice
  * @property label Portion label
  * @property amount Price of the product in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
-*/
+ */
 @Serializable
 data class LabeledPrice(
     val label: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/OrderInfo.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/OrderInfo.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents information about an order.
+ *
  * Api reference: https://core.telegram.org/bots/api#orderinfo
  * @property name Optional. User name
  * @property phoneNumber Optional. User's phone number
  * @property email Optional. User email
  * @property shippingAddress Optional. User shipping address
-*/
+ */
 @Serializable
 data class OrderInfo(
     val name: String? = null,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/PreCheckoutQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/PreCheckoutQuery.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains information about an incoming pre-checkout query.
+ *
  * Api reference: https://core.telegram.org/bots/api#precheckoutquery
  * @property id Unique query identifier
  * @property from User who sent the query
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property invoicePayload Bot specified invoice payload
  * @property shippingOptionId Optional. Identifier of the shipping option chosen by the user
  * @property orderInfo Optional. Order information provided by the user
-*/
+ */
 @Serializable
 data class PreCheckoutQuery(
     val id: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/ShippingAddress.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/ShippingAddress.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents a shipping address.
+ *
  * Api reference: https://core.telegram.org/bots/api#shippingaddress
  * @property countryCode Two-letter ISO 3166-1 alpha-2 country code
  * @property state State, if applicable
@@ -11,7 +12,7 @@ import kotlinx.serialization.Serializable
  * @property streetLine1 First line for the address
  * @property streetLine2 Second line for the address
  * @property postCode Address post code
-*/
+ */
 @Serializable
 data class ShippingAddress(
     val countryCode: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/ShippingOption.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/ShippingOption.kt
@@ -4,11 +4,12 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object represents one shipping option.
+ *
  * Api reference: https://core.telegram.org/bots/api#shippingoption
  * @property id Shipping option identifier
  * @property title Option title
  * @property prices List of price portions
-*/
+ */
 @Serializable
 data class ShippingOption(
     val id: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/ShippingQuery.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/ShippingQuery.kt
@@ -5,12 +5,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains information about an incoming shipping query.
+ *
  * Api reference: https://core.telegram.org/bots/api#shippingquery
  * @property id Unique query identifier
  * @property from User who sent the query
  * @property invoicePayload Bot specified invoice payload
  * @property shippingAddress User specified shipping address
-*/
+ */
 @Serializable
 data class ShippingQuery(
     val id: String,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/SuccessfulPayment.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/payment/SuccessfulPayment.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This object contains basic information about a successful payment.
+ *
  * Api reference: https://core.telegram.org/bots/api#successfulpayment
  * @property currency Three-letter ISO 4217 currency code
  * @property totalAmount Total price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
@@ -13,7 +14,7 @@ import kotlinx.serialization.Serializable
  * @property orderInfo Optional. Order information provided by the user
  * @property telegramPaymentChargeId Telegram payment identifier
  * @property providerPaymentChargeId Provider payment identifier
-*/
+ */
 @Serializable
 data class SuccessfulPayment(
     val currency: Currency,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/BotUtils.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/BotUtils.kt
@@ -113,5 +113,5 @@ internal inline fun <T> Any?.cast() = this as T
 
 expect inline fun <T : ChainLink> InputListener.setChain(user: User, firstLink: T)
 
-@Suppress("ObjectPropertyName")
+@Suppress("ObjectPropertyName", "ktlint:standard:backing-property-naming")
 expect val _OperatingActivities: Map<String, List<Any?>>

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/ComponentConfigurations.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/ComponentConfigurations.kt
@@ -24,7 +24,7 @@ internal inline fun TelegramBot.getConfiguredHttpClient() = config.httpClient.ru
         }
 
         install(Logging) {
-            logger = KorLogger("HttpClient").apply { setLevel(LogLvl.TRACE) }
+            logger = Logging("HttpClient").logger.apply { setLevel(LogLvl.TRACE) }
             level = config.logging.httpLogLevel.toKtorLvl()
         }
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.kt
@@ -18,4 +18,3 @@ abstract class Logger(val id: String) : io.ktor.client.plugins.logging.Logger {
 internal expect open class Logging(tag: String = "TelegramBot") {
     val logger: Logger
 }
-

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.kt
@@ -15,7 +15,7 @@ abstract class Logger(val id: String) : io.ktor.client.plugins.logging.Logger {
 }
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-internal expect open class Logging(tag: String) {
+internal expect open class Logging(tag: String = "TelegramBot") {
     val logger: Logger
 }
 

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.kt
@@ -1,11 +1,8 @@
 package eu.vendeli.tgbot.utils
 
 import eu.vendeli.tgbot.types.internal.LogLvl
-import korlibs.logger.BaseConsole
-import korlibs.logger.BaseConsole.Kind
-import kotlinx.datetime.Clock
 
-abstract class Logger(private val id: String) : io.ktor.client.plugins.logging.Logger {
+abstract class Logger(val id: String) : io.ktor.client.plugins.logging.Logger {
     abstract fun setLevel(level: LogLvl)
     abstract fun info(message: () -> String): Unit?
     abstract fun warn(message: () -> String): Unit?
@@ -17,40 +14,8 @@ abstract class Logger(private val id: String) : io.ktor.client.plugins.logging.L
     }
 }
 
-internal open class KorLogger(private val id: String) : Logger(id) {
-    private val logger = BaseConsole()
-
-    private var lvl = Kind.INFO
-
-    override fun setLevel(level: LogLvl) {
-        lvl = when (level) {
-            LogLvl.OFF -> throw NotImplementedError()
-            LogLvl.ERROR -> Kind.ERROR
-            LogLvl.WARN -> Kind.WARN
-            LogLvl.INFO -> Kind.INFO
-            LogLvl.DEBUG -> Kind.DEBUG
-            LogLvl.TRACE -> Kind.TRACE
-            LogLvl.ALL -> Kind.LOG
-        }
-    }
-
-    override fun info(message: () -> String) = log(Kind.INFO) { message() }
-    override fun warn(message: () -> String) = log(Kind.WARN) { message() }
-    override fun debug(message: () -> String) = log(Kind.DEBUG) { message() }
-    override fun trace(message: () -> String) = log(Kind.TRACE) { message() }
-    override fun error(throwable: Throwable?, message: () -> String) = log(Kind.ERROR, throwable) { message() }
-
-    @Suppress("NOTHING_TO_INLINE")
-    private inline fun String.logEntry(
-        kind: Kind,
-    ) = "${Clock.System.now()} [$id] $kind $this"
-    private inline fun log(level: Kind, throwable: Throwable? = null, message: () -> String): Unit? =
-        if (level.ordinal <= lvl.ordinal)
-            throwable?.let { logger.log(level, message().logEntry(level), it) }
-                ?: logger.log(level, message().logEntry(level))
-        else null
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+internal expect open class Logging(tag: String) {
+    val logger: Logger
 }
 
-internal open class Logging(id: String = "TelegramBot") {
-    val logger: Logger = KorLogger(id)
-}

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/ProcessUpdate.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/ProcessUpdate.kt
@@ -1,12 +1,16 @@
 package eu.vendeli.tgbot.utils
 
 import eu.vendeli.tgbot.types.Update
+import eu.vendeli.tgbot.types.internal.BusinessConnectionUpdate
+import eu.vendeli.tgbot.types.internal.BusinessMessageUpdate
 import eu.vendeli.tgbot.types.internal.CallbackQueryUpdate
 import eu.vendeli.tgbot.types.internal.ChannelPostUpdate
 import eu.vendeli.tgbot.types.internal.ChatBoostUpdate
 import eu.vendeli.tgbot.types.internal.ChatJoinRequestUpdate
 import eu.vendeli.tgbot.types.internal.ChatMemberUpdate
 import eu.vendeli.tgbot.types.internal.ChosenInlineResultUpdate
+import eu.vendeli.tgbot.types.internal.DeletedBusinessMessagesUpdate
+import eu.vendeli.tgbot.types.internal.EditedBusinessMessageUpdate
 import eu.vendeli.tgbot.types.internal.EditedChannelPostUpdate
 import eu.vendeli.tgbot.types.internal.EditedMessageUpdate
 import eu.vendeli.tgbot.types.internal.InlineQueryUpdate
@@ -40,5 +44,9 @@ fun Update.processUpdate() = when {
     chatJoinRequest != null -> ChatJoinRequestUpdate(updateId, this, chatJoinRequest)
     chatBoost != null -> ChatBoostUpdate(updateId, this, chatBoost)
     removedChatBoost != null -> RemovedChatBoostUpdate(updateId, this, removedChatBoost)
+    businessConnection != null -> BusinessConnectionUpdate(updateId, this, businessConnection)
+    businessMessage != null -> BusinessMessageUpdate(updateId, this, businessMessage)
+    editedBusinessMessage != null -> EditedBusinessMessageUpdate(updateId, this, editedBusinessMessage)
+    deletedBusinessMessages != null -> DeletedBusinessMessagesUpdate(updateId, this, deletedBusinessMessages)
     else -> throw IllegalArgumentException("Unknown type of update.")
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/TypeAliases.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/TypeAliases.kt
@@ -7,6 +7,8 @@ import eu.vendeli.tgbot.interfaces.ClassManager
 import eu.vendeli.tgbot.types.Update
 import eu.vendeli.tgbot.types.User
 import eu.vendeli.tgbot.types.internal.ActivityCtx
+import eu.vendeli.tgbot.types.internal.BusinessConnectionUpdate
+import eu.vendeli.tgbot.types.internal.BusinessMessageUpdate
 import eu.vendeli.tgbot.types.internal.CallbackQueryUpdate
 import eu.vendeli.tgbot.types.internal.ChannelPostUpdate
 import eu.vendeli.tgbot.types.internal.ChatBoostUpdate
@@ -14,6 +16,8 @@ import eu.vendeli.tgbot.types.internal.ChatJoinRequestUpdate
 import eu.vendeli.tgbot.types.internal.ChatMemberUpdate
 import eu.vendeli.tgbot.types.internal.ChosenInlineResultUpdate
 import eu.vendeli.tgbot.types.internal.CommandContext
+import eu.vendeli.tgbot.types.internal.DeletedBusinessMessagesUpdate
+import eu.vendeli.tgbot.types.internal.EditedBusinessMessageUpdate
 import eu.vendeli.tgbot.types.internal.EditedChannelPostUpdate
 import eu.vendeli.tgbot.types.internal.EditedMessageUpdate
 import eu.vendeli.tgbot.types.internal.FunctionalInvocation
@@ -54,6 +58,10 @@ typealias OnMessageReactionActivity = suspend ActivityCtx<MessageReactionUpdate>
 typealias OnMessageReactionCountActivity = suspend ActivityCtx<MessageReactionCountUpdate>.() -> Unit
 typealias OnChatBoostActivity = suspend ActivityCtx<ChatBoostUpdate>.() -> Unit
 typealias OnRemovedChatBoostActivity = suspend ActivityCtx<RemovedChatBoostUpdate>.() -> Unit
+typealias OnBusinessConnectionActivity = suspend ActivityCtx<BusinessConnectionUpdate>.() -> Unit
+typealias OnBusinessMessageActivity = suspend ActivityCtx<BusinessMessageUpdate>.() -> Unit
+typealias OnEditedBusinessMessageActivity = suspend ActivityCtx<EditedBusinessMessageUpdate>.() -> Unit
+typealias OnDeletedBusinessMessagesActivity = suspend ActivityCtx<DeletedBusinessMessagesUpdate>.() -> Unit
 
 typealias WhenNotHandledActivity = suspend Update.() -> Unit
 typealias OnCommandActivity = suspend CommandContext<ProcessedUpdate>.() -> Unit

--- a/telegram-bot/src/jsMain/kotlin/eu/vendeli/tgbot/utils/BotUtils.js.kt
+++ b/telegram-bot/src/jsMain/kotlin/eu/vendeli/tgbot/utils/BotUtils.js.kt
@@ -19,6 +19,6 @@ fun TelegramBot.defineActivities(input: Map<String, List<Any?>>) {
 }
 private var activities: Map<String, List<Any?>> = emptyMap()
 
-@Suppress("ObjectPropertyName")
+@Suppress("ObjectPropertyName", "ktlint:standard:backing-property-naming")
 actual val _OperatingActivities: Map<String, List<Any?>>
     get() = activities

--- a/telegram-bot/src/jsMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.js.kt
+++ b/telegram-bot/src/jsMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.js.kt
@@ -1,0 +1,41 @@
+package eu.vendeli.tgbot.utils
+
+import co.touchlab.kermit.DefaultFormatter
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.mutableLoggerConfigInit
+import co.touchlab.kermit.platformLogWriter
+import eu.vendeli.tgbot.types.internal.LogLvl
+
+internal open class KermitLogger(id: String) : Logger(id) {
+    private val logger = co.touchlab.kermit.Logger(
+        mutableLoggerConfigInit(platformLogWriter(DefaultFormatter), minSeverity = Severity.Info),
+        id,
+    )
+
+    private var lvl = Severity.Info
+
+    override fun setLevel(level: LogLvl) {
+        lvl = when (level) {
+            LogLvl.OFF -> throw NotImplementedError()
+            LogLvl.ERROR -> Severity.Error
+            LogLvl.WARN -> Severity.Warn
+            LogLvl.INFO -> Severity.Info
+            LogLvl.DEBUG -> Severity.Debug
+            LogLvl.TRACE -> Severity.Verbose
+            LogLvl.ALL -> Severity.Verbose
+        }
+        logger.mutableConfig.minSeverity = lvl
+    }
+
+    override fun info(message: () -> String) = logger.i(message = message)
+    override fun warn(message: () -> String) = logger.w(message = message)
+    override fun debug(message: () -> String) = logger.d(message = message)
+    override fun trace(message: () -> String) = logger.v(message = message)
+    override fun error(throwable: Throwable?, message: () -> String) =
+        logger.e(throwable = throwable, message = message)
+}
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+internal actual open class Logging actual constructor(tag: String) {
+    actual val logger: Logger = KermitLogger(tag)
+}

--- a/telegram-bot/src/jvmMain/kotlin/eu/vendeli/tgbot/utils/BotUtils.jvm.kt
+++ b/telegram-bot/src/jvmMain/kotlin/eu/vendeli/tgbot/utils/BotUtils.jvm.kt
@@ -28,6 +28,6 @@ private var activities: Map<String, List<Any?>> = runCatching {
         .invoke(null) as Map<String, List<Any?>>
 }.getOrNull() ?: emptyMap()
 
-@Suppress("ObjectPropertyName")
+@Suppress("ObjectPropertyName", "ktlint:standard:backing-property-naming")
 actual val _OperatingActivities: Map<String, List<Any?>>
     get() = activities

--- a/telegram-bot/src/jvmMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.jvm.kt
+++ b/telegram-bot/src/jvmMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.jvm.kt
@@ -4,7 +4,7 @@ import ch.qos.logback.classic.Level
 import eu.vendeli.tgbot.types.internal.LogLvl
 import org.slf4j.LoggerFactory
 
-internal open class Sl4jLogger(id: String) : Logger(id) {
+internal open class LogbackLogger(id: String) : Logger(id) {
     private val logger = LoggerFactory.getLogger(id)
 
     private var lvl = Level.INFO
@@ -33,5 +33,5 @@ internal open class Sl4jLogger(id: String) : Logger(id) {
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 internal actual open class Logging actual constructor(tag: String) {
-    actual val logger: Logger = Sl4jLogger(tag)
+    actual val logger: Logger = LogbackLogger(tag)
 }

--- a/telegram-bot/src/jvmMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.jvm.kt
+++ b/telegram-bot/src/jvmMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.jvm.kt
@@ -1,0 +1,37 @@
+package eu.vendeli.tgbot.utils
+
+import ch.qos.logback.classic.Level
+import eu.vendeli.tgbot.types.internal.LogLvl
+import org.slf4j.LoggerFactory
+
+internal open class Sl4jLogger(id: String) : Logger(id) {
+    private val logger = LoggerFactory.getLogger(id)
+
+    private var lvl = Level.INFO
+
+    override fun setLevel(level: LogLvl) {
+        lvl = when (level) {
+            LogLvl.OFF -> throw NotImplementedError()
+            LogLvl.ERROR -> Level.ERROR
+            LogLvl.WARN -> Level.WARN
+            LogLvl.INFO -> Level.INFO
+            LogLvl.DEBUG -> Level.DEBUG
+            LogLvl.TRACE -> Level.TRACE
+            LogLvl.ALL -> Level.TRACE
+        }
+        val root = LoggerFactory.getLogger(id) as ch.qos.logback.classic.Logger
+        root.setLevel(lvl)
+    }
+
+    override fun info(message: () -> String) = logger.info(message())
+    override fun warn(message: () -> String) = logger.warn(message())
+    override fun debug(message: () -> String) = logger.debug(message())
+    override fun trace(message: () -> String) = logger.trace(message())
+    override fun error(throwable: Throwable?, message: () -> String) =
+        logger.error(message(), throwable)
+}
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+internal actual open class Logging actual constructor(tag: String) {
+    actual val logger: Logger = Sl4jLogger(tag)
+}

--- a/telegram-bot/src/jvmTest/kotlin/BotTestContext.kt
+++ b/telegram-bot/src/jvmTest/kotlin/BotTestContext.kt
@@ -140,5 +140,5 @@ abstract class BotTestContext(
         ) as T
     }
 
-    internal companion object : Logging()
+    internal companion object : Logging("TgUpdateHandler")
 }

--- a/telegram-bot/src/jvmTest/kotlin/BotTestContext.kt
+++ b/telegram-bot/src/jvmTest/kotlin/BotTestContext.kt
@@ -29,7 +29,6 @@ import io.mockk.mockkStatic
 import io.mockk.spyk
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.sync.Mutex
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.JsonElement
@@ -37,17 +36,6 @@ import kotlinx.serialization.serializer
 import kotlin.properties.Delegates
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.seconds
-
-private val mutex = Mutex()
-private suspend fun Mutex.toggle() = if (isLocked) unlock() else lock()
-private val BOT_DATA: Iterator<Pair<Long, String>> = generateSequence {
-    runBlocking {
-        mutex.toggle()
-        System.getenv("BOT_TOKEN" + if (mutex.isLocked) "_2" else "").let {
-            it.substringBefore(':').toLong() to it
-        }
-    }
-}.iterator()
 
 @Suppress("VariableNaming", "PropertyName", "PrivatePropertyName", "SpellCheckingInspection")
 abstract class BotTestContext(
@@ -61,7 +49,6 @@ abstract class BotTestContext(
     private val updatesAction = spyk(GET_UPDATES_ACTION)
     protected var classloader: ClassLoader = Thread.currentThread().contextClassLoader
 
-    private val BOT_CTX get() = BOT_DATA.next()
     protected val TG_ID by lazy { System.getenv("TELEGRAM_ID").toLong() }
     protected var BOT_ID by Delegates.notNull<Long>()
     protected val CHAT_ID by lazy { System.getenv("CHAT_ID").toLong() }
@@ -80,9 +67,9 @@ abstract class BotTestContext(
     @BeforeAll
     @OptIn(InternalApi::class)
     fun prepareTestBot() {
-        val ctx = BOT_CTX
-        BOT_ID = ctx.first
-        if (withPreparedBot) bot = TelegramBot(ctx.second, "eu.vendeli") {
+        val ctx = BotInstance.current
+        BOT_ID = ctx.id
+        if (withPreparedBot) bot = TelegramBot(ctx.token, "eu.vendeli") {
             logging {
                 botLogLevel = LogLvl.DEBUG
                 httpLogLevel = HttpLogLevel.BODY

--- a/telegram-bot/src/jvmTest/kotlin/BotTestContext.kt
+++ b/telegram-bot/src/jvmTest/kotlin/BotTestContext.kt
@@ -140,5 +140,5 @@ abstract class BotTestContext(
         ) as T
     }
 
-    internal companion object : Logging("TgUpdateHandler")
+    internal companion object : Logging("BotTest")
 }

--- a/telegram-bot/src/jvmTest/kotlin/TestUtils.kt
+++ b/telegram-bot/src/jvmTest/kotlin/TestUtils.kt
@@ -1,0 +1,27 @@
+data class BotData(
+    val id: Long,
+    val token: String,
+)
+
+object BotInstance {
+    private val pool = listOf(
+        System.getenv("BOT_TOKEN").let {
+            BotData(it.substringBefore(':').toLong(), it)
+        },
+        System.getenv("BOT_TOKEN_2").let {
+            BotData(it.substringBefore(':').toLong(), it)
+        },
+    )
+
+    @Volatile
+    var isMain = false
+
+    val current: BotData
+        get() {
+            isMain = isMain.not()
+            return if (isMain) main else secondary
+        }
+
+    val main: BotData get() = pool.first()
+    val secondary: BotData get() = pool.last()
+}

--- a/telegram-bot/src/jvmTest/kotlin/eu/vendeli/FunctionalHandlingTest.kt
+++ b/telegram-bot/src/jvmTest/kotlin/eu/vendeli/FunctionalHandlingTest.kt
@@ -156,6 +156,10 @@ class FunctionalHandlingTest : BotTestContext(true, true) {
             onChatJoinRequest { onUpdateInvocationsCount++ }
             onChatBoost { onUpdateInvocationsCount++ }
             onRemovedChatBoost { onUpdateInvocationsCount++ }
+            onBusinessConnection { onUpdateInvocationsCount++ }
+            onBusinessMessage { onUpdateInvocationsCount++ }
+            onEditedBusinessMessage { onUpdateInvocationsCount++ }
+            onDeletedBusinessMessages { onUpdateInvocationsCount++ }
         }
 
         UpdateType.entries.forEach {

--- a/telegram-bot/src/jvmTest/kotlin/eu/vendeli/api/botactions/BusinessActionsTest.kt
+++ b/telegram-bot/src/jvmTest/kotlin/eu/vendeli/api/botactions/BusinessActionsTest.kt
@@ -1,0 +1,13 @@
+package eu.vendeli.api.botactions
+
+import BotTestContext
+import eu.vendeli.tgbot.api.botactions.getBusinessConnection
+import eu.vendeli.tgbot.types.internal.getOrNull
+import io.kotest.matchers.shouldBe
+
+class BusinessActionsTest : BotTestContext() {
+    @Test
+    suspend fun `getBusinessConnection method testing`() {
+        getBusinessConnection("test").sendAsync(bot).getOrNull()?.user?.id?.shouldBe(TG_ID)
+    }
+}

--- a/telegram-bot/src/jvmTest/kotlin/eu/vendeli/api/media/MediaTest.kt
+++ b/telegram-bot/src/jvmTest/kotlin/eu/vendeli/api/media/MediaTest.kt
@@ -15,6 +15,7 @@ import eu.vendeli.tgbot.api.media.sticker
 import eu.vendeli.tgbot.api.media.video
 import eu.vendeli.tgbot.api.media.videoNote
 import eu.vendeli.tgbot.api.media.voice
+import eu.vendeli.tgbot.types.ParseMode
 import eu.vendeli.utils.LOREM
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -25,7 +26,9 @@ class MediaTest : BotTestContext() {
     @Test
     suspend fun `audio method test`() {
         val lorem = LOREM.AUDIO
-        val bytesResult = audio(lorem.bytes).sendReturning(TG_ID, bot).shouldSuccess()
+        val bytesResult = audio(lorem.bytes)
+            .caption { "test" }.options { parseMode = ParseMode.Markdown }
+            .sendReturning(TG_ID, bot).shouldSuccess()
         val textResult = sendAudio { bytesResult.audio!!.fileId }.sendReturning(TG_ID, bot).shouldSuccess()
         val fileResult = audio(lorem.file).sendReturning(TG_ID, bot).shouldSuccess()
         val inputResult = audio(lorem.inputFile).sendReturning(TG_ID, bot).shouldSuccess()
@@ -44,7 +47,9 @@ class MediaTest : BotTestContext() {
     @Test
     suspend fun `animation method test`() {
         val lorem = LOREM.ANIMATION
-        val textResult = sendAnimation { lorem.url }.sendReturning(TG_ID, bot).shouldSuccess()
+        val textResult = sendAnimation { lorem.url }
+            .caption { "test" }.options { parseMode = ParseMode.Markdown }
+            .sendReturning(TG_ID, bot).shouldSuccess()
         val bytesResult = animation(lorem.bytes).sendReturning(TG_ID, bot).shouldSuccess()
         val fileResult = animation(lorem.file).sendReturning(TG_ID, bot).shouldSuccess()
         val inputResult = animation(lorem.inputFile).sendReturning(TG_ID, bot).shouldSuccess()

--- a/telegram-bot/src/jvmTest/kotlin/eu/vendeli/api/stickerset/StickerBaseTest.kt
+++ b/telegram-bot/src/jvmTest/kotlin/eu/vendeli/api/stickerset/StickerBaseTest.kt
@@ -8,6 +8,7 @@ import eu.vendeli.tgbot.api.stickerset.deleteStickerFromSet
 import eu.vendeli.tgbot.api.stickerset.deleteStickerSet
 import eu.vendeli.tgbot.api.stickerset.getCustomEmojiStickers
 import eu.vendeli.tgbot.api.stickerset.getStickerSet
+import eu.vendeli.tgbot.api.stickerset.replaceStickerInSet
 import eu.vendeli.tgbot.api.stickerset.setStickerEmojiList
 import eu.vendeli.tgbot.api.stickerset.setStickerKeywords
 import eu.vendeli.tgbot.api.stickerset.setStickerMaskPosition
@@ -56,14 +57,26 @@ class StickerBaseTest : BotTestContext() {
         val result = createNewStickerSet(
             setName,
             "test_2",
-            StickerFormat.Static,
             listOf(
                 InputSticker(
                     TEMP_STICKER_FILE_ID.toImplicitFile(),
+                    StickerFormat.Static,
                     listOf("\uD83D\uDCAF"),
                 ),
             ),
         ).sendReturning(TG_ID, bot).shouldSuccess()
+
+        val oldSticker = getStickerSet(setName).sendAsync(bot).shouldSuccess().stickers.first()
+        replaceStickerInSet(
+            userId = TG_ID,
+            name = setName,
+            oldSticker = oldSticker.fileId,
+            sticker = InputSticker(
+                LOREM.STICKER.inputFile.toImplicitFile(),
+                StickerFormat.Animated,
+                listOf("\uD83D\uDC4D\uD83C\uDFFB", "\uD83D\uDC05"),
+            ),
+        ).sendAsync(TG_ID, bot).getOrNull()?.shouldBeTrue()
 
         result.shouldBeTrue()
 
@@ -79,8 +92,6 @@ class StickerBaseTest : BotTestContext() {
 
         with(result) {
             name shouldBe setName
-            isAnimated shouldBe false
-            isVideo shouldBe false
             title shouldBe "test_2"
             stickerType shouldBe StickerType.Regular
             stickers.size shouldBeGreaterThanOrEqual 0
@@ -94,10 +105,15 @@ class StickerBaseTest : BotTestContext() {
 
         val addResult = addStickerToSet(
             setName,
-            InputSticker(TEMP_STICKER_FILE_ID.toImplicitFile(), listOf("\uD83D\uDC4D\uD83C\uDFFB")),
+            InputSticker(
+                TEMP_STICKER_FILE_ID.toImplicitFile(),
+                StickerFormat.Static,
+                listOf("\uD83D\uDC4D\uD83C\uDFFB"),
+            ),
         ).sendAsync(TG_ID, bot).shouldSuccess()
         addResult.shouldBeTrue()
-        val fileId = getStickerSet(setName).sendAsync(bot).shouldSuccess().stickers.last().fileId
+        val stickerList = getStickerSet(setName).sendAsync(bot).shouldSuccess().stickers
+        val fileId = stickerList.last().fileId
 
         val setEmojiListResult = setStickerEmojiList(
             fileId,
@@ -117,7 +133,8 @@ class StickerBaseTest : BotTestContext() {
         ).sendAsync(bot).shouldSuccess()
         setStickerPositionInSetResult.shouldBeTrue()
 
-        val setStickerSetThumbnailResult = setStickerSetThumbnail(setName).sendAsync(TG_ID, bot).shouldSuccess()
+        val setStickerSetThumbnailResult = setStickerSetThumbnail(setName, StickerFormat.Static)
+            .sendAsync(TG_ID, bot).shouldSuccess()
         setStickerSetThumbnailResult.shouldBeTrue()
 
         val setStickerMaskPositionResult = setStickerMaskPosition(
@@ -152,10 +169,10 @@ class StickerBaseTest : BotTestContext() {
         val result = createNewStickerSet(
             setName,
             "test_2",
-            StickerFormat.Static,
             listOf(
                 InputSticker(
                     TEMP_STICKER_FILE_ID.toImplicitFile(),
+                    StickerFormat.Static,
                     listOf("\uD83D\uDCAF"),
                 ),
             ),
@@ -166,6 +183,7 @@ class StickerBaseTest : BotTestContext() {
 
         val setCustomEmojiStickerSetThumbnailResult = setStickerSetThumbnail(
             setName,
+            StickerFormat.Static,
             TEMP_STICKER_FILE_ID.toImplicitFile(),
         ).sendAsync(TG_ID, bot).shouldSuccess()
         setCustomEmojiStickerSetThumbnailResult.shouldBeTrue()

--- a/telegram-bot/src/jvmTest/kotlin/eu/vendeli/fixtures/GeneratedActivities.kt
+++ b/telegram-bot/src/jvmTest/kotlin/eu/vendeli/fixtures/GeneratedActivities.kt
@@ -41,7 +41,8 @@ private val `TG_$COMMANDS`: Map<Pair<String, UpdateType>, Invocable> = mapOf(
                 TgAnnotationsModel
             val param0 = bot
             TgAnnotationsModel::stopHandling.invoke(
-                inst, param0,
+                inst,
+                param0,
             )
         }
             to InvocationMeta("eu.vendeli.fixtures.TgAnnotationsModel", "stopHandling", zeroRateLimits)
@@ -142,7 +143,8 @@ private val `TG_$REGEX`: Map<Regex, Invocable> = mapOf(
                 RegexCommands
             val param0 = bot
             RegexCommands::testR.invoke(
-                inst, param0,
+                inst,
+                param0,
             )
         }
             to InvocationMeta("eu.vendeli.fixtures.RegexCommands", "testR", zeroRateLimits)

--- a/telegram-bot/src/linuxMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.linux.kt
+++ b/telegram-bot/src/linuxMain/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.linux.kt
@@ -1,0 +1,41 @@
+package eu.vendeli.tgbot.utils
+
+import co.touchlab.kermit.DefaultFormatter
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.mutableLoggerConfigInit
+import co.touchlab.kermit.platformLogWriter
+import eu.vendeli.tgbot.types.internal.LogLvl
+
+internal open class KermitLogger(id: String) : Logger(id) {
+    private val logger = co.touchlab.kermit.Logger(
+        mutableLoggerConfigInit(platformLogWriter(DefaultFormatter), minSeverity = Severity.Info),
+        id,
+    )
+
+    private var lvl = Severity.Info
+
+    override fun setLevel(level: LogLvl) {
+        lvl = when (level) {
+            LogLvl.OFF -> throw NotImplementedError()
+            LogLvl.ERROR -> Severity.Error
+            LogLvl.WARN -> Severity.Warn
+            LogLvl.INFO -> Severity.Info
+            LogLvl.DEBUG -> Severity.Debug
+            LogLvl.TRACE -> Severity.Verbose
+            LogLvl.ALL -> Severity.Verbose
+        }
+        logger.mutableConfig.minSeverity = lvl
+    }
+
+    override fun info(message: () -> String) = logger.i(message = message)
+    override fun warn(message: () -> String) = logger.w(message = message)
+    override fun debug(message: () -> String) = logger.d(message = message)
+    override fun trace(message: () -> String) = logger.v(message = message)
+    override fun error(throwable: Throwable?, message: () -> String) =
+        logger.e(throwable = throwable, message = message)
+}
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+internal actual open class Logging actual constructor(tag: String) {
+    actual val logger: Logger = KermitLogger(tag)
+}

--- a/telegram-bot/src/mingwX64Main/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.mingwX64.kt
+++ b/telegram-bot/src/mingwX64Main/kotlin/eu/vendeli/tgbot/utils/LoggingUtils.mingwX64.kt
@@ -1,0 +1,41 @@
+package eu.vendeli.tgbot.utils
+
+import co.touchlab.kermit.DefaultFormatter
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.mutableLoggerConfigInit
+import co.touchlab.kermit.platformLogWriter
+import eu.vendeli.tgbot.types.internal.LogLvl
+
+internal open class KermitLogger(id: String) : Logger(id) {
+    private val logger = co.touchlab.kermit.Logger(
+        mutableLoggerConfigInit(platformLogWriter(DefaultFormatter), minSeverity = Severity.Info),
+        id,
+    )
+
+    private var lvl = Severity.Info
+
+    override fun setLevel(level: LogLvl) {
+        lvl = when (level) {
+            LogLvl.OFF -> throw NotImplementedError()
+            LogLvl.ERROR -> Severity.Error
+            LogLvl.WARN -> Severity.Warn
+            LogLvl.INFO -> Severity.Info
+            LogLvl.DEBUG -> Severity.Debug
+            LogLvl.TRACE -> Severity.Verbose
+            LogLvl.ALL -> Severity.Verbose
+        }
+        logger.mutableConfig.minSeverity = lvl
+    }
+
+    override fun info(message: () -> String) = logger.i(message = message)
+    override fun warn(message: () -> String) = logger.w(message = message)
+    override fun debug(message: () -> String) = logger.d(message = message)
+    override fun trace(message: () -> String) = logger.v(message = message)
+    override fun error(throwable: Throwable?, message: () -> String) =
+        logger.e(throwable = throwable, message = message)
+}
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+internal actual open class Logging actual constructor(tag: String) {
+    actual val logger: Logger = KermitLogger(tag)
+}

--- a/telegram-bot/src/nativeMain/kotlin/eu/vendeli/tgbot/implementations/ClassManagerImpl.native.kt
+++ b/telegram-bot/src/nativeMain/kotlin/eu/vendeli/tgbot/implementations/ClassManagerImpl.native.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KClass
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual class ClassManagerImpl : ClassManager {
-    @Suppress("PropertyName")
+    @Suppress("PropertyName", "ktlint:standard:backing-property-naming")
     val _INSTANCES: MutableMap<KClass<*>, Any> = mutableMapOf()
     override fun getInstance(kClass: KClass<*>, vararg initParams: Any?): Any = _INSTANCES[kClass]
         ?: error("Class $kClass not found.")

--- a/telegram-bot/src/nativeMain/kotlin/eu/vendeli/tgbot/utils/BotUtils.native.kt
+++ b/telegram-bot/src/nativeMain/kotlin/eu/vendeli/tgbot/utils/BotUtils.native.kt
@@ -18,6 +18,6 @@ fun TelegramBot.defineActivities(input: Map<String, List<Any?>>) {
 }
 private var activities: Map<String, List<Any?>> = emptyMap()
 
-@Suppress("ObjectPropertyName")
+@Suppress("ObjectPropertyName", "ktlint:standard:backing-property-naming")
 actual val _OperatingActivities: Map<String, List<Any?>>
     get() = activities


### PR DESCRIPTION
* Fixed multipart requests data redundant quotation.
* Returned `logback` as logger for `jvm` target.
* Moved inline mode methods to extension interface from separate `InlinableAction`.
* Added `Any` upperbounds for `Autowiring` interface to avoid wrong behaviour.
* Covered 7.2 TelegramApi changes.