### PR TITLE
6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Telegram-bot (KtGram) changelog
 
+### 6.5.0
+
+* Added `button(...)` function to define button in `answerInlineQuery` options.
+* Added method `toWebhookResponse` to actions to give an option to respond to webhook.
+* Added separate `bot.update.parse(...)`, helpful if you're using webhook responses.
+* Fixed incorrect request url resolution when using multiple bot instances.
+* Added ability to share `httpClient` between instances in ktor starter, spring starter will also use the httClient, if
+  bean is defined.
+
 ### 6.4.1
 
 * Fix `SuccessfulPayment` absence of `orderInfo` nullability bug.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ deteKT = "1.23.6"
 
 kotest = "5.9.1"
 mockk = "1.13.12"
-kover = "0.8.2"
+kover = "0.8.3"
 krypto = "4.0.10"
 sslcontext = "8.3.6"
 spring = "3.3.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ mockk = "1.13.12"
 kover = "0.8.2"
 krypto = "4.0.10"
 sslcontext = "8.3.6"
-spring = "3.3.1"
+spring = "3.3.2"
 
 ksp = "2.0.0-1.0.23"
 poet = "1.18.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spring = "3.3.2"
 ksp = "2.0.0-1.0.23"
 poet = "1.18.1"
 
-binvalid = "0.16.1"
+binvalid = "0.16.2"
 
 [libraries]
 # ktor

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spring = "3.3.2"
 ksp = "2.0.0-1.0.23"
 poet = "1.18.1"
 
-binvalid = "0.16.0"
+binvalid = "0.16.1"
 
 [libraries]
 # ktor

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spring = "3.3.1"
 ksp = "2.0.0-1.0.23"
 poet = "1.18.1"
 
-binvalid = "0.15.1"
+binvalid = "0.16.0"
 
 [libraries]
 # ktor

--- a/ktor-starter/build.gradle.kts
+++ b/ktor-starter/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
     jvmToolchain(JAVA_TARGET_V_int)
     jvm()
     sourceSets {
-        named("jvmMain") {
+        jvmMain {
             dependencies {
                 compileOnly(project(":telegram-bot"))
                 api(libs.ktor.server.core)

--- a/ktor-starter/build.gradle.kts
+++ b/ktor-starter/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
         jvmMain {
             dependencies {
                 compileOnly(project(":telegram-bot"))
+                compileOnly(libs.ktor.client.core)
                 api(libs.ktor.server.core)
                 api(libs.ktor.server.netty)
                 implementation(libs.ssl.utils)

--- a/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/BotConfiguration.kt
+++ b/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/BotConfiguration.kt
@@ -12,7 +12,7 @@ class BotConfiguration {
 
     var token by Delegates.notNull<String>()
     var pckg: String? = null
-    var identifier = "KtGram"
+    var identifier: String? = null
 
     fun configuration(config: BotConfigurator) {
         configuration = config

--- a/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/BotConfiguration.kt
+++ b/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/BotConfiguration.kt
@@ -12,7 +12,7 @@ class BotConfiguration {
 
     var token by Delegates.notNull<String>()
     var pckg: String? = null
-    var identifier by Delegates.notNull<String>()
+    var identifier = "KtGram"
 
     fun configuration(config: BotConfigurator) {
         configuration = config

--- a/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/BotConfiguration.kt
+++ b/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/BotConfiguration.kt
@@ -2,13 +2,12 @@ package eu.vendeli.ktor.starter
 
 import eu.vendeli.tgbot.TelegramBot
 import eu.vendeli.tgbot.utils.BotConfigurator
-import eu.vendeli.tgbot.utils.DEFAULT_HANDLING_BEHAVIOUR
 import eu.vendeli.tgbot.utils.HandlingBehaviourBlock
 import kotlin.properties.Delegates
 
 class BotConfiguration {
     internal var configuration: BotConfigurator = {}
-    internal var handlingBehaviour: HandlingBehaviourBlock = DEFAULT_HANDLING_BEHAVIOUR
+    internal var handlingBehaviour: HandlingBehaviourBlock? = null
     internal var onInitHook: suspend (bot: TelegramBot) -> Unit = {}
 
     var token by Delegates.notNull<String>()

--- a/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/KtorServer.kt
+++ b/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/KtorServer.kt
@@ -62,7 +62,6 @@ fun serveWebhook(wait: Boolean = true, serverBuilder: ServerBuilder.() -> Unit =
             }
         }
 
-        modules.addAll(cfg.ktorModules)
         modules.add {
             routing {
                 cfg.botInstances.forEach { (token, bot) ->
@@ -75,6 +74,7 @@ fun serveWebhook(wait: Boolean = true, serverBuilder: ServerBuilder.() -> Unit =
                 }
             }
         }
+        modules.addAll(cfg.ktorModules)
     }
 
     return embeddedServer(Netty, environment, cfg.engineCfg).start(wait)

--- a/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/KtorServer.kt
+++ b/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/KtorServer.kt
@@ -1,5 +1,6 @@
 package eu.vendeli.ktor.starter
 
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.engine.applicationEngineEnvironment
@@ -10,7 +11,7 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.netty.NettyApplicationEngine
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respond
-import io.ktor.server.routing.post
+import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import nl.altindag.ssl.pem.util.PemUtils
 import java.io.File
@@ -62,12 +63,14 @@ fun serveWebhook(wait: Boolean = true, serverBuilder: ServerBuilder.() -> Unit =
         }
 
         modules.addAll(cfg.ktorModules)
-        module {
+        modules.add {
             routing {
                 cfg.botInstances.forEach { (token, bot) ->
-                    post("${cfg.WEBHOOK_PREFIX}$token") {
-                        bot.update.parseAndHandle(call.receiveText())
-                        call.respond(HttpStatusCode.OK)
+                    route("${cfg.WEBHOOK_PREFIX}$token", HttpMethod.Post) {
+                        handle {
+                            bot.update.parseAndHandle(call.receiveText())
+                            call.respond(HttpStatusCode.OK)
+                        }
                     }
                 }
             }

--- a/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/ServerBuilder.kt
+++ b/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/ServerBuilder.kt
@@ -16,15 +16,15 @@ class ServerBuilder internal constructor() {
         server = ManualConfiguration().apply(configurator)
     }
 
-    fun declareBot(block: BotConfiguration.() -> Unit) = BotConfiguration().apply(block).also {
-        botInstances[it.token] = TelegramBot(
-            it.token,
-            it.pckg,
-            it.configuration,
+    fun declareBot(block: BotConfiguration.() -> Unit) = BotConfiguration().apply(block).also { cfg ->
+        botInstances[cfg.token] = TelegramBot(
+            cfg.token,
+            cfg.pckg,
+            cfg.configuration,
         ).also { bot ->
-            bot.identifier = it.identifier
-            bot.update.setBehaviour(it.handlingBehaviour)
-            runBlocking { it.onInitHook.invoke(bot) }
+            bot.identifier = cfg.identifier
+            cfg.handlingBehaviour?.let { bot.update.setBehaviour(it) }
+            runBlocking { cfg.onInitHook.invoke(bot) }
         }
     }
 

--- a/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/ServerBuilder.kt
+++ b/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/ServerBuilder.kt
@@ -1,6 +1,9 @@
 package eu.vendeli.ktor.starter
 
 import eu.vendeli.tgbot.TelegramBot
+import eu.vendeli.tgbot.annotations.internal.InternalApi
+import eu.vendeli.tgbot.utils.getConfiguredHttpClient
+import io.ktor.client.HttpClient
 import io.ktor.server.application.Application
 import io.ktor.server.netty.NettyApplicationEngine
 import kotlinx.coroutines.runBlocking
@@ -10,17 +13,27 @@ class ServerBuilder internal constructor() {
     internal val ktorModules = mutableListOf<Application.() -> Unit>()
     internal var server: Configuration? = null
     internal var engineCfg: NettyApplicationEngine.Configuration.() -> Unit = {}
+    private var httpClient: HttpClient? = null
+    var shareHttpClient: Boolean = false
     var WEBHOOK_PREFIX = "/"
 
     fun server(configurator: ManualConfiguration.() -> Unit) {
         server = ManualConfiguration().apply(configurator)
     }
 
+    @OptIn(InternalApi::class)
     fun declareBot(block: BotConfiguration.() -> Unit) = BotConfiguration().apply(block).also { cfg ->
+        val client = if (shareHttpClient) httpClient ?: getConfiguredHttpClient(
+            eu.vendeli.tgbot.types.internal.configuration.BotConfiguration(),
+        ) else null
+
         botInstances[cfg.token] = TelegramBot(
-            cfg.token,
-            cfg.pckg,
-            cfg.configuration,
+            token = cfg.token,
+            commandsPackage = cfg.pckg,
+            httpClient = client?.also {
+                httpClient = it
+            },
+            botConfiguration = cfg.configuration,
         ).also { bot ->
             cfg.identifier?.let { bot.identifier = it }
             cfg.handlingBehaviour?.let { bot.update.setBehaviour(it) }

--- a/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/ServerBuilder.kt
+++ b/ktor-starter/src/jvmMain/kotlin/eu/vendeli/ktor/starter/ServerBuilder.kt
@@ -22,7 +22,7 @@ class ServerBuilder internal constructor() {
             cfg.pckg,
             cfg.configuration,
         ).also { bot ->
-            bot.identifier = cfg.identifier
+            cfg.identifier?.let { bot.identifier = it }
             cfg.handlingBehaviour?.let { bot.update.setBehaviour(it) }
             runBlocking { cfg.onInitHook.invoke(bot) }
         }

--- a/spring-ktgram-starter/build.gradle.kts
+++ b/spring-ktgram-starter/build.gradle.kts
@@ -7,9 +7,10 @@ kotlin {
     jvmToolchain(JAVA_TARGET_V_int)
     jvm()
     sourceSets {
-        named("jvmMain") {
+        jvmMain {
             dependencies {
                 compileOnly(project(":telegram-bot"))
+                compileOnly(libs.ktor.client.core)
                 compileOnly(libs.spring.starter)
             }
         }

--- a/spring-ktgram-starter/src/jvmMain/kotlin/eu/vendeli/spring/starter/TelegramAutoConfiguration.kt
+++ b/spring-ktgram-starter/src/jvmMain/kotlin/eu/vendeli/spring/starter/TelegramAutoConfiguration.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.spring.starter
 
 import eu.vendeli.tgbot.TelegramBot
+import io.ktor.client.HttpClient
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -21,11 +22,14 @@ open class TelegramAutoConfiguration(
     @Autowired(required = false)
     private lateinit var cfg: List<BotConfiguration>
 
+    @Autowired(required = false)
+    private lateinit var client: HttpClient
+
     @Bean
     @OptIn(DelicateCoroutinesApi::class)
     open fun botInstances(): List<TelegramBot> = config.bot.map { bot ->
-        val botCfg = if (this::cfg.isInitialized) cfg.find { bot.identifier == it.identifier } else null
-        val botInstance = TelegramBot(bot.token, bot.pckg) {
+        val botCfg = cfg.takeIf { ::cfg.isInitialized }?.find { bot.identifier == it.identifier }
+        val botInstance = TelegramBot(bot.token, bot.pckg, client.takeIf { ::cfg.isInitialized }) {
             classManager = springClassManager
             botCfg?.let { this.apply(it.applyCfg()) }
         }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/TelegramBot.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/TelegramBot.kt
@@ -40,6 +40,8 @@ class TelegramBot(
 
     internal val config = BotConfiguration().apply(botConfiguration)
 
+    internal val baseUrl by lazy { "${config.apiHost}/bot$token" + if (config.isTestEnv) "/test/" else "/" }
+
     /**
      * A tool for managing input waiting.
      */

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/TelegramBot.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/TelegramBot.kt
@@ -1,5 +1,6 @@
 package eu.vendeli.tgbot
 
+import eu.vendeli.tgbot.annotations.internal.InternalApi
 import eu.vendeli.tgbot.core.CodegenUpdateHandler
 import eu.vendeli.tgbot.core.FunctionalHandlingDsl
 import eu.vendeli.tgbot.core.TgUpdateHandler
@@ -11,6 +12,7 @@ import eu.vendeli.tgbot.utils.BotConfigurator
 import eu.vendeli.tgbot.utils.FunctionalHandlingBlock
 import eu.vendeli.tgbot.utils.Logging
 import eu.vendeli.tgbot.utils.getConfiguredHttpClient
+import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.readBytes
 
@@ -36,6 +38,16 @@ class TelegramBot(
         configLoader.commandsPackage,
     ) {
         config.apply(configLoader.load())
+    }
+
+    @OptIn(InternalApi::class)
+    constructor(
+        token: String,
+        commandsPackage: String? = null,
+        httpClient: HttpClient? = null,
+        botConfiguration: BotConfigurator = {},
+    ) : this(token, commandsPackage, botConfiguration) {
+        this.httpClient = httpClient ?: getConfiguredHttpClient(config)
     }
 
     internal val config = BotConfiguration().apply(botConfiguration)
@@ -71,7 +83,8 @@ class TelegramBot(
      */
     val update: TgUpdateHandler = CodegenUpdateHandler(commandsPackage, this)
 
-    internal val httpClient = getConfiguredHttpClient()
+    @OptIn(InternalApi::class)
+    internal var httpClient = getConfiguredHttpClient(config)
 
     /**
      * Get direct url from [File] if [File.filePath] is present

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/core/TgUpdateHandler.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/core/TgUpdateHandler.kt
@@ -34,7 +34,7 @@ abstract class TgUpdateHandler internal constructor(
     internal val handlerScope = bot.config.updatesListener.run {
         CoroutineScope(dispatcher + CoroutineName("TgBot"))
     }
-    internal val functionalHandlingBehavior = FunctionalHandlingDsl(bot)
+    internal val functionalHandlingBehavior by lazy { FunctionalHandlingDsl(bot) }
 
     /**
      * The channel where errors caught during update processing are stored with update that caused them.

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/core/TgUpdateHandler.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/core/TgUpdateHandler.kt
@@ -110,20 +110,25 @@ abstract class TgUpdateHandler internal constructor(
      * A method for handling updates from a string.
      * Define processing behavior before calling, see [setBehaviour].
      */
-    suspend fun parseAndHandle(update: String) {
+    suspend fun parseAndHandle(update: String) = parse(update)
+        ?.let {
+            logger.debug { "Processing update with preset behaviour." }
+            coHandle(
+                bot.config.updatesListener.processingDispatcher,
+            ) { handlingBehaviour(this@TgUpdateHandler, it) }
+        }
+
+    /**
+     * A method to parse update from string.
+     */
+    fun parse(update: String): ProcessedUpdate? {
         logger.debug { "Trying to parse update from string - $update" }
-        serde
+        return serde
             .runCatching { decodeFromString(ProcessedUpdate.serializer(), update) }
             .onFailure {
                 logger.error(it) { "error during the update parsing process." }
             }.onSuccess { logger.info { "Successfully parsed update to $it" } }
             .getOrNull()
-            ?.let {
-                logger.debug { "Processing update with preset behaviour." }
-                coHandle(
-                    bot.config.updatesListener.processingDispatcher,
-                ) { handlingBehaviour(this@TgUpdateHandler, it) }
-            }
     }
 
     /**

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/TgAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/TgAction.kt
@@ -25,6 +25,7 @@ abstract class TgAction<ReturnType> : Request<ReturnType> {
      * [there](https://core.telegram.org/bots/faq#how-can-i-make-requests-in-response-to-updates).
      */
     fun toWebhookResponse(): String {
+        require(multipartData.isEmpty()) { "Multipart files is not supported for webhook response flow." }
         parameters["method"] = method.name.toJsonElement()
         return serde.encodeToString(parameters)
     }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/TgAction.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/interfaces/TgAction.kt
@@ -7,9 +7,12 @@ import eu.vendeli.tgbot.types.internal.TgMethod
 import eu.vendeli.tgbot.types.internal.options.Options
 import eu.vendeli.tgbot.utils.makeRequestReturning
 import eu.vendeli.tgbot.utils.makeSilentRequest
+import eu.vendeli.tgbot.utils.serde
+import eu.vendeli.tgbot.utils.toJsonElement
 import io.ktor.http.content.PartData
 import kotlinx.coroutines.Deferred
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonElement
 import kotlin.properties.Delegates
 
@@ -17,6 +20,15 @@ import kotlin.properties.Delegates
  * Tg action, see [Actions article](https://github.com/vendelieu/telegram-bot/wiki/Actions)
  */
 abstract class TgAction<ReturnType> : Request<ReturnType> {
+    /**
+     * Payload to make response for the webhook request as described
+     * [there](https://core.telegram.org/bots/faq#how-can-i-make-requests-in-response-to-updates).
+     */
+    fun toWebhookResponse(): String {
+        parameters["method"] = method.name.toJsonElement()
+        return serde.encodeToString(parameters)
+    }
+
     /**
      * A method that is implemented in Action.
      */

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/options/AnswerInlineQueryOptions.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/options/AnswerInlineQueryOptions.kt
@@ -11,11 +11,11 @@ data class AnswerInlineQueryOptions(
     var nextOffset: String? = null,
     var button: InlineQueryResultsButton? = null,
 ) : Options {
-    fun button(text: String, webAppInfo: () -> WebAppInfo) {
-        button = InlineQueryResultsButton(text, webApp = webAppInfo())
+    fun button(text: String, webAppInfoUrl: () -> String) {
+        button = InlineQueryResultsButton(text, webApp = WebAppInfo(url = webAppInfoUrl()))
     }
 
-    fun button(text: String, startParameter: () -> String) {
-        button = InlineQueryResultsButton(text, startParameter = startParameter())
+    fun button(text: String, startParameter: String) {
+        button = InlineQueryResultsButton(text, startParameter = startParameter)
     }
 }

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/options/AnswerInlineQueryOptions.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/options/AnswerInlineQueryOptions.kt
@@ -1,6 +1,7 @@
 package eu.vendeli.tgbot.types.internal.options
 
 import eu.vendeli.tgbot.types.inline.InlineQueryResultsButton
+import eu.vendeli.tgbot.types.keyboard.WebAppInfo
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -9,4 +10,12 @@ data class AnswerInlineQueryOptions(
     var isPersonal: Boolean? = null,
     var nextOffset: String? = null,
     var button: InlineQueryResultsButton? = null,
-) : Options
+) : Options {
+    fun button(text: String, webAppInfo: () -> WebAppInfo) {
+        button = InlineQueryResultsButton(text, webApp = webAppInfo())
+    }
+
+    fun button(text: String, startParameter: () -> String) {
+        button = InlineQueryResultsButton(text, startParameter = startParameter())
+    }
+}

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/BotRequestExtensions.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/BotRequestExtensions.kt
@@ -62,15 +62,6 @@ private suspend inline fun <T> HttpResponse.toResult(type: KSerializer<T>) = bod
     else serde.decodeFromString(Response.Failure.serializer(), it)
 }
 
-@Suppress("ktlint:standard:backing-property-naming")
-private var _baseUrl: String? = null
-private val TelegramBot.baseUrl: String
-    get() {
-        if (_baseUrl != null) return _baseUrl!!
-        _baseUrl = "${config.apiHost}/bot$token" + if (config.isTestEnv) "/test/" else "/"
-        return _baseUrl!!
-    }
-
 internal suspend inline fun <T> TelegramBot.makeRequestReturning(
     method: TgMethod,
     data: Map<String, JsonElement>,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/ComponentConfigurations.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/ComponentConfigurations.kt
@@ -1,8 +1,9 @@
 package eu.vendeli.tgbot.utils
 
-import eu.vendeli.tgbot.TelegramBot
 import eu.vendeli.tgbot.TelegramBot.Companion.logger
+import eu.vendeli.tgbot.annotations.internal.InternalApi
 import eu.vendeli.tgbot.types.internal.LogLvl
+import eu.vendeli.tgbot.types.internal.configuration.BotConfiguration
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
@@ -14,8 +15,8 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun TelegramBot.getConfiguredHttpClient() = config.httpClient.run cfg@{
+@InternalApi
+fun getConfiguredHttpClient(config: BotConfiguration) = config.httpClient.run cfg@{
     HttpClient {
         install("RequestLogging") {
             sendPipeline.intercept(HttpSendPipeline.Monitoring) {


### PR DESCRIPTION
* Added `button(...)` function to define button in `answerInlineQuery` options.
* Added method `toWebhookResponse` to actions to give an option to respond to webhook.
* Added separate `bot.update.parse(...)`, helpful if you're using webhook responses.
* Fixed incorrect request url resolution when using multiple bot instances.
* Added ability to share `httpClient` between instances in ktor starter, spring starter will also use the httClient, if
  bean is defined.