### PR TITLE
fix: rename UpdateType.EDIT_MESSAGE to EDITED_MESSAGE

### DIFF
--- a/telegram-bot/api/telegram-bot.api
+++ b/telegram-bot/api/telegram-bot.api
@@ -8036,7 +8036,7 @@ public final class eu/vendeli/tgbot/types/internal/UpdateType : java/lang/Enum {
 	public static final field DELETED_BUSINESS_MESSAGES Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field EDITED_BUSINESS_MESSAGE Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field EDITED_CHANNEL_POST Leu/vendeli/tgbot/types/internal/UpdateType;
-	public static final field EDIT_MESSAGE Leu/vendeli/tgbot/types/internal/UpdateType;
+	public static final field EDITED_MESSAGE Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field INLINE_QUERY Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field MESSAGE Leu/vendeli/tgbot/types/internal/UpdateType;
 	public static final field MESSAGE_REACTION Leu/vendeli/tgbot/types/internal/UpdateType;

--- a/telegram-bot/api/telegram-bot.klib.api
+++ b/telegram-bot/api/telegram-bot.klib.api
@@ -376,7 +376,7 @@ final enum class eu.vendeli.tgbot.types.internal/UpdateType : kotlin/Enum<eu.ven
     enum entry DELETED_BUSINESS_MESSAGES // eu.vendeli.tgbot.types.internal/UpdateType.DELETED_BUSINESS_MESSAGES|null[0]
     enum entry EDITED_BUSINESS_MESSAGE // eu.vendeli.tgbot.types.internal/UpdateType.EDITED_BUSINESS_MESSAGE|null[0]
     enum entry EDITED_CHANNEL_POST // eu.vendeli.tgbot.types.internal/UpdateType.EDITED_CHANNEL_POST|null[0]
-    enum entry EDIT_MESSAGE // eu.vendeli.tgbot.types.internal/UpdateType.EDIT_MESSAGE|null[0]
+    enum entry EDITED_MESSAGE // eu.vendeli.tgbot.types.internal/UpdateType.EDITED_MESSAGE|null[0]
     enum entry INLINE_QUERY // eu.vendeli.tgbot.types.internal/UpdateType.INLINE_QUERY|null[0]
     enum entry MESSAGE // eu.vendeli.tgbot.types.internal/UpdateType.MESSAGE|null[0]
     enum entry MESSAGE_REACTION // eu.vendeli.tgbot.types.internal/UpdateType.MESSAGE_REACTION|null[0]

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/ProcessedUpdate.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/ProcessedUpdate.kt
@@ -63,7 +63,7 @@ data class EditedMessageUpdate(
     override val updateId: Int,
     override val origin: Update,
     val editedMessage: Message,
-) : ProcessedUpdate(updateId, origin, UpdateType.EDIT_MESSAGE),
+) : ProcessedUpdate(updateId, origin, UpdateType.EDITED_MESSAGE),
     UserReference {
     override val user = editedMessage.from!!
     override val text = editedMessage.text.orEmpty()

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/UpdateType.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/types/internal/UpdateType.kt
@@ -8,8 +8,8 @@ enum class UpdateType {
     @SerialName("message")
     MESSAGE,
 
-    @SerialName("edit_message")
-    EDIT_MESSAGE,
+    @SerialName("edited_message")
+    EDITED_MESSAGE,
 
     @SerialName("channel_post")
     CHANNEL_POST,

--- a/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/FunctionalDSLUtils.kt
+++ b/telegram-bot/src/commonMain/kotlin/eu/vendeli/tgbot/utils/FunctionalDSLUtils.kt
@@ -39,7 +39,7 @@ public fun FunctionalHandlingDsl.onMessage(block: suspend ActivityCtx<MessageUpd
  * Action that is performed on the presence of [eu.vendeli.tgbot.types.Update.editedMessage] in the [eu.vendeli.tgbot.types.Update].
  */
 public fun FunctionalHandlingDsl.onEditedMessage(block: suspend ActivityCtx<EditedMessageUpdate>.() -> Unit) {
-  functionalActivities.onUpdateActivities[UpdateType.EDIT_MESSAGE] = block.cast()
+  functionalActivities.onUpdateActivities[UpdateType.EDITED_MESSAGE] = block.cast()
 }
 
 /**


### PR DESCRIPTION
See https://core.telegram.org/bots/api#update for more info.

Correct `SerialName` for `EDIT_MESSAGE` is `edited_message`. I also renamed `EDIT_MESSAGE` to `EDITED_MESSAGE ` for more consistency.

How to reproduce error: Pass to `allowedUpdates` all update types (`UpdateType.entries`) and stop receiving edit message updates.
