### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ build.gradle.kts example:
 plugins {
     // ...
     id("com.google.devtools.ksp") version "2.2.0-2.0.2"
-    id("eu.vendeli.telegram-bot") version "8.3.0"
+    id("eu.vendeli.telegram-bot") version "8.3.1"
 }
 ```
 
@@ -39,8 +39,8 @@ plugins {
 
 dependencies {
     // ...
-    implementation("eu.vendeli:telegram-bot:8.3.0")
-    ksp("eu.vendeli:ksp:8.3.0")
+    implementation("eu.vendeli:telegram-bot:8.3.1")
+    ksp("eu.vendeli:ksp:8.3.1")
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ mockk = "1.14.4"
 kover = "0.9.1"
 krypto = "4.0.10"
 urlencoder = "1.6.0"
-sslcontext = "9.1.0"
+ayza = "10.0.0"
 spring = "3.5.3"
 
 ksp = "2.2.0-2.0.2"
@@ -71,7 +71,7 @@ poet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "poet" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 ksp-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 
-ssl-utils = { module = "io.github.hakky54:sslcontext-kickstart-for-pem", version.ref = "sslcontext" }
+ayza = { module = "io.github.hakky54:ayza-for-pem", version.ref = "ayza" }
 spring-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "spring" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 publisher = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "publisher" }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other
  open [Pull Requests](https://github.com/vendelieu/telegram-bot/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Description
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience
